### PR TITLE
Add user docs link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ Codex must be able to:
 - Radioss Input Syntax Reference: <https://help.altair.com/hwsolvers/rad/index.htm>
 - OpenRadioss GitHub: <https://github.com/OpenRadioss/OpenRadioss>
 - Radioss Examples (Starter/Engine): <https://github.com/OpenRadioss/OpenRadioss-examples>
+- OpenRadioss User Documentation: <https://openradioss.atlassian.net/wiki/spaces/OPENRADIOSS/pages/4816906/OpenRadioss+User+Documentation>
 
 ## ✅ Development style guide
 All modules should use pure Python 3.10+, no external dependencies.


### PR DESCRIPTION
## Summary
- reference the official OpenRadioss user documentation in `AGENTS.md`

## Testing
- `python scripts/run_all.py --help` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685b14bce2d883279afca6492c71724d