### PR TITLE
Add OpenRadioss setup utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .venv/
 __pycache__/
 *.pyc
+openradioss_bin/
+*.zip

--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ incluye un ejemplo mínimo.
 python scripts/run_all.py data/model.cdb --inc mesh.inp --rad model_0000.rad
 ```
 
+### Entorno virtual y OpenRadioss
+
+Para crear un entorno virtual con `pytest` y descargar la última
+versión binaria de OpenRadioss:
+
+```bash
+python scripts/create_venv.py
+python scripts/download_openradioss.py
+```
+
+Después se puede ejecutar OpenRadioss sobre el fichero generado. El propio
+script ajusta las variables de entorno necesarias (`RAD_CFG_PATH` y
+`LD_LIBRARY_PATH`) al usar `--exec`:
+
+```bash
+python scripts/run_all.py data/model.cdb --rad model.rad \
+    --exec openradioss_bin/OpenRadioss/exec/starter_linux64_gf
+```
+
 Para lanzar las pruebas:
 
 ```bash

--- a/scripts/create_venv.py
+++ b/scripts/create_venv.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Create a local virtual environment and install dev tools."""
+import subprocess
+import sys
+from pathlib import Path
+
+VENV_DIR = Path('.venv')
+
+
+def main() -> None:
+    if VENV_DIR.exists():
+        print(f"Virtual environment already exists at {VENV_DIR}")
+        return
+    subprocess.run([sys.executable, '-m', 'venv', str(VENV_DIR)], check=True)
+    pip = VENV_DIR / 'bin' / 'pip'
+    if not pip.exists():
+        pip = VENV_DIR / 'Scripts' / 'pip.exe'
+    packages = ['pytest']
+    subprocess.run([str(pip), 'install', '--upgrade', 'pip'], check=True)
+    subprocess.run([str(pip), 'install', *packages], check=True)
+    print('Virtual environment ready')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/download_openradioss.py
+++ b/scripts/download_openradioss.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Download and extract the latest OpenRadioss binary release."""
+from __future__ import annotations
+import json
+import urllib.request
+import zipfile
+from pathlib import Path
+import sys
+import os
+import tempfile
+
+DEST = Path('openradioss_bin')
+API_URL = 'https://api.github.com/repos/OpenRadioss/OpenRadioss/releases/latest'
+
+
+def latest_linux_asset() -> str | None:
+    with urllib.request.urlopen(API_URL) as resp:
+        release = json.load(resp)
+    for asset in release.get('assets', []):
+        name = asset.get('name', '')
+        if name.endswith('linux64.zip'):
+            return asset['browser_download_url']
+    return None
+
+
+def download(url: str, path: Path) -> None:
+    with urllib.request.urlopen(url) as resp, open(path, 'wb') as out:
+        out.write(resp.read())
+
+
+def main() -> None:
+    if (DEST / 'exec').exists():
+        print('OpenRadioss already installed')
+        return
+    asset_url = latest_linux_asset()
+    if not asset_url:
+        print('Could not find OpenRadioss asset', file=sys.stderr)
+        sys.exit(1)
+    DEST.mkdir(exist_ok=True)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        zip_path = Path(tmpdir) / 'or.zip'
+        print(f'Downloading {asset_url}...')
+        download(asset_url, zip_path)
+        with zipfile.ZipFile(zip_path) as zf:
+            zf.extractall(DEST)
+    print(f'OpenRadioss extracted to {DEST}')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -1,5 +1,6 @@
 """CLI to convert .cdb files."""
 import argparse
+import subprocess
 
 from cdb2rad.parser import parse_cdb
 from cdb2rad.writer_inc import write_mesh_inp
@@ -11,6 +12,11 @@ def main() -> None:
     parser.add_argument("cdb_file", help="Input .cdb file")
     parser.add_argument("--rad", dest="rad", help="Output .rad file")
     parser.add_argument("--inc", dest="inc", help="Output mesh.inp file")
+    parser.add_argument(
+        "--exec",
+        dest="exec_path",
+        help="Run OpenRadioss starter after generation",
+    )
 
     args = parser.parse_args()
 
@@ -20,6 +26,16 @@ def main() -> None:
         write_mesh_inp(nodes, elements, args.inc)
     if args.rad:
         write_rad(nodes, elements, args.rad)
+        if args.exec_path:
+            from pathlib import Path
+            import os
+
+            exe = Path(args.exec_path).resolve()
+            base = exe.parent.parent
+            env = os.environ.copy()
+            env.setdefault('RAD_CFG_PATH', str(base / 'hm_cfg_files'))
+            env.setdefault('LD_LIBRARY_PATH', str(base / 'extlib' / 'hm_reader' / 'linux64'))
+            subprocess.run([str(exe), '-i', args.rad], check=False, env=env)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- provide helper script to create a virtual environment
- provide downloader for the latest OpenRadioss binaries
- extend `run_all.py` with ability to execute the solver
- update `.gitignore`
- document workflow in README
- set `RAD_CFG_PATH`/`LD_LIBRARY_PATH` automatically when running solver

## Testing
- `pytest -q`
- ran translator on `model.cdb` and invoked solver via `--exec`

------
https://chatgpt.com/codex/tasks/task_e_685b1c79bccc8327b92cb2f15b52888f