### PR TITLE
Fix run_all imports for direct execution

### DIFF
--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -1,6 +1,13 @@
 """CLI to convert .cdb files."""
 import argparse
 import subprocess
+import sys
+from pathlib import Path
+
+# Ensure the repository root is on sys.path when executed directly
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from cdb2rad.parser import parse_cdb
 from cdb2rad.writer_inc import write_mesh_inp


### PR DESCRIPTION
## Summary
- ensure run_all.py can locate the `cdb2rad` package when called directly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b244a4a7483279d299d968156abda