### PR TITLE
Add named selections and material parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@ Ansys a un *input deck* compatible con OpenRadioss.
 ## ¿Qué hace el código?
 
 1. Lee bloques ``NBLOCK`` y ``EBLOCK`` de un ``.cdb``.
-2. Genera un fichero ``mesh.inp`` con ``/NODE`` y bloques de elementos
-   derivados de ``mapping.json`` (``/SHELL``, ``/BRICK``, ``/TETRA``...).
-3. Crea ``model_0000.rad`` que incluye ``mesh.inp`` y define propiedades,
+2. Detecta selecciones nombradas (``CMBLOCK``) y datos de material
+   (``MPDATA``).
+3. Genera un fichero ``mesh.inp`` con ``/NODE`` y bloques de elementos
+   derivados de ``mapping.json`` (``/SHELL``, ``/BRICK``, ``/TETRA``...). Las
+   selecciones y los materiales se exportan en formato Radioss.
+4. Crea ``model_0000.rad`` que incluye ``mesh.inp`` y define propiedades,
    materiales, condiciones de contorno y ejemplos de contacto y carga.
 
 ## Entrada requerida

--- a/cdb2rad/writer_inc.py
+++ b/cdb2rad/writer_inc.py
@@ -10,8 +10,15 @@ def write_mesh_inp(
     elements: List[Tuple[int, int, List[int]]],
     outfile: str,
     mapping_file: str | None = None,
+    node_sets: Dict[str, List[int]] | None = None,
+    elem_sets: Dict[str, List[int]] | None = None,
+    materials: Dict[int, Dict[str, float]] | None = None,
 ) -> None:
-    """Write ``mesh.inp`` with element blocks derived from ``mapping.json``."""
+    """Write ``mesh.inp`` with element blocks derived from ``mapping.json``.
+
+    Optionally, node and element sets (from CMBLOCK) and basic material
+    properties can be written for later use in the starter file.
+    """
 
     if mapping_file is None:
         mapping_path = Path(__file__).with_name("mapping.json")
@@ -47,3 +54,25 @@ def write_mesh_inp(
             for eid, nids in items:
                 line = f"{eid:10d}" + "".join(f"{nid:10d}" for nid in nids)
                 f.write(line + "\n")
+
+        if node_sets:
+            for idx, (name, nids) in enumerate(node_sets.items(), start=1):
+                f.write(f"\n/GRNOD/NODE/{idx}\n")
+                f.write(f"{name}\n")
+                for nid in nids:
+                    f.write(f"{nid:10d}\n")
+
+        if elem_sets:
+            for idx, (name, eids) in enumerate(elem_sets.items(), start=1):
+                f.write(f"\n/SET/EL/{idx}\n")
+                f.write(f"{name}\n")
+                for eid in eids:
+                    f.write(f"{eid:10d}\n")
+
+        if materials:
+            for mid, props in materials.items():
+                e = props.get("EX", 210000.0)
+                nu = props.get("NUXY", 0.3)
+                rho = props.get("DENS", 7800.0)
+                f.write(f"\n/MAT/LAW1/{mid}\n")
+                f.write(f"{e} {nu} {rho}\n")

--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -15,10 +15,20 @@ def write_rad(
     elements: List[Tuple[int, int, List[int]]],
     outfile: str,
     mesh_inc: str = "mesh.inp",
+    node_sets: Dict[str, List[int]] | None = None,
+    elem_sets: Dict[str, List[int]] | None = None,
+    materials: Dict[int, Dict[str, float]] | None = None,
 ) -> None:
     """Generate a minimal ``model_0000.rad`` file and the referenced mesh."""
 
-    write_mesh_inp(nodes, elements, mesh_inc)
+    write_mesh_inp(
+        nodes,
+        elements,
+        mesh_inc,
+        node_sets=node_sets,
+        elem_sets=elem_sets,
+        materials=materials,
+    )
 
     with open(outfile, "w") as f:
         f.write("/BEGIN\n")
@@ -30,8 +40,16 @@ def write_rad(
         f.write("/PROP/SHELL/1\n")
         f.write(f"{DEFAULT_THICKNESS}\n")
 
-        f.write("/MAT/LAW1/1\n")
-        f.write(f"{DEFAULT_E} {DEFAULT_NU} {DEFAULT_RHO}\n")
+        if not materials:
+            f.write("/MAT/LAW1/1\n")
+            f.write(f"{DEFAULT_E} {DEFAULT_NU} {DEFAULT_RHO}\n")
+        else:
+            for mid, props in materials.items():
+                e = props.get("EX", DEFAULT_E)
+                nu = props.get("NUXY", DEFAULT_NU)
+                rho = props.get("DENS", DEFAULT_RHO)
+                f.write(f"/MAT/LAW1/{mid}\n")
+                f.write(f"{e} {nu} {rho}\n")
 
         f.write("/BOUNDARY/BCS/1\n")
         f.write("1 1 1 1 1 1\n")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -7,24 +7,40 @@ DATA = os.path.join(os.path.dirname(__file__), '..', 'data', 'model.cdb')
 
 
 def test_parse_cdb():
-    nodes, elements = parse_cdb(DATA)
+    nodes, elements, node_sets, elem_sets, materials = parse_cdb(DATA)
     assert len(nodes) == 2032
     assert len(elements) == 2479
+    assert "BALL" in elem_sets
+    assert "TARGET" in elem_sets
 
 
 def test_write_mesh(tmp_path):
-    nodes, elements = parse_cdb(DATA)
+    nodes, elements, node_sets, elem_sets, materials = parse_cdb(DATA)
     out = tmp_path / 'mesh.inp'
-    write_mesh_inp(nodes, elements, str(out))
+    write_mesh_inp(
+        nodes,
+        elements,
+        str(out),
+        node_sets=node_sets,
+        elem_sets=elem_sets,
+        materials=materials,
+    )
     text = out.read_text()
     assert '/NODE' in text
     assert '/BRICK' in text
 
 
 def test_write_rad(tmp_path):
-    nodes, elements = parse_cdb(DATA)
+    nodes, elements, node_sets, elem_sets, materials = parse_cdb(DATA)
     rad = tmp_path / 'model.rad'
-    write_rad(nodes, elements, str(rad))
+    write_rad(
+        nodes,
+        elements,
+        str(rad),
+        node_sets=node_sets,
+        elem_sets=elem_sets,
+        materials=materials,
+    )
     content = rad.read_text()
     assert '/BEGIN' in content
     assert '/END' in content


### PR DESCRIPTION
## Summary
- parse CMBLOCK and MPDATA in `parse_cdb`
- export groups and materials in `write_mesh_inp`
- allow passing groups/materials to `write_rad`
- update tests and docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b248d950c8327af569efc378a5a4e