### PR TITLE
Add Streamlit dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,17 @@ Para lanzar las pruebas:
 ```bash
 pytest -q
 ```
+
+## Interfaz web
+
+Se incluye una pequeña interfaz en Streamlit para cargar un `.cdb`, visualizar
+el número de nodos y elementos y generar los ficheros ``mesh.inp`` y
+``model_0000.rad`` de forma interactiva. Para ejecutarla:
+
+```bash
+streamlit run src/dashboard/app.py
+```
+
+Se puede subir un archivo propio o seleccionar ``data_files/model.cdb`` como
+ejemplo. Tras pulsar *Generar input deck* se muestran las primeras líneas de
+``mesh.inp``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+streamlit

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1,0 +1,56 @@
+import tempfile
+from pathlib import Path
+
+import streamlit as st
+
+from cdb2rad.parser import parse_cdb
+from cdb2rad.writer_rad import write_rad
+
+
+@st.cache_data(ttl=3600)
+def load_cdb(path: str):
+    return parse_cdb(path)
+
+
+st.title("CDB → OpenRadioss")
+
+uploaded = st.file_uploader("Subir archivo .cdb", type="cdb")
+example_dir = Path("data_files")
+examples = [p.name for p in example_dir.glob("*.cdb")]
+selected = st.selectbox("o escoger ejemplo", [""] + examples)
+
+file_path = None
+if uploaded is not None:
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".cdb")
+    tmp.write(uploaded.getvalue())
+    tmp.close()
+    file_path = tmp.name
+elif selected:
+    file_path = str(example_dir / selected)
+
+if file_path:
+    nodes, elements, node_sets, elem_sets, materials = load_cdb(file_path)
+    st.write("Nodos:", len(nodes))
+    st.write("Elementos:", len(elements))
+    st.write("Conjuntos de nodos:", len(node_sets))
+    st.write("Conjuntos de elementos:", len(elem_sets))
+    st.write("Materiales:", len(materials))
+
+    if st.button("Generar input deck"):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rad_path = Path(tmpdir) / "model_0000.rad"
+            mesh_path = Path(tmpdir) / "mesh.inp"
+            write_rad(
+                nodes,
+                elements,
+                str(rad_path),
+                mesh_inc=str(mesh_path),
+                node_sets=node_sets,
+                elem_sets=elem_sets,
+                materials=materials,
+            )
+            st.success("Ficheros generados en directorio temporal")
+            lines = mesh_path.read_text().splitlines()[:20]
+            st.code("\n".join(lines))
+else:
+    st.info("Sube o selecciona un archivo .cdb")


### PR DESCRIPTION
## Summary
- build a small Streamlit interface in `src/dashboard/app.py`
- declare the Streamlit dependency
- document how to launch the dashboard

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b2a1e66908327b8535d79f1d89e72