### PR TITLE
Update run_all defaults

### DIFF
--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -23,6 +23,11 @@ def main() -> None:
 
     args = parser.parse_args()
 
+    if not args.rad and not args.inc:
+        # default output names when none are provided
+        args.inc = "mesh.inp"
+        args.rad = "model_0000.rad"
+
     nodes, elements, node_sets, elem_sets, materials = parse_cdb(args.cdb_file)
 
     if args.inc:


### PR DESCRIPTION
## Summary
- ensure output names are populated when no `--rad` or `--inc` arguments are given
- propagate node/element sets and materials as before

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b2a1d01988327b0a81c8f3232f2af