### PR TITLE
Add 3D preview tab to Streamlit dashboard

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1,6 +1,9 @@
 import tempfile
 from pathlib import Path
 import sys
+import json
+import math
+from typing import Dict, List
 
 import streamlit as st
 
@@ -10,6 +13,50 @@ if root_path not in sys.path:
 
 from cdb2rad.parser import parse_cdb
 from cdb2rad.writer_rad import write_rad
+
+
+def viewer_html(nodes: Dict[int, List[float]]) -> str:
+    """Return a small Three.js viewer for the given nodes."""
+    if not nodes:
+        return "<p>No data</p>"
+    coords = list(nodes.values())
+    xs = [c[0] for c in coords]
+    ys = [c[1] for c in coords]
+    zs = [c[2] for c in coords]
+    cx = sum(xs) / len(xs)
+    cy = sum(ys) / len(ys)
+    cz = sum(zs) / len(zs)
+    max_r = 0.0
+    for x, y, z in coords:
+        r = math.sqrt((x - cx) ** 2 + (y - cy) ** 2 + (z - cz) ** 2)
+        if r > max_r:
+            max_r = r
+    cam_dist = max_r * 3 if max_r > 0 else 10.0
+    return f"""
+<div id='c'></div>
+<script src='https://cdn.jsdelivr.net/npm/three@0.154.0/build/three.min.js'></script>
+<script>
+const pts = {json.dumps(coords)};
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(70, 1, 0.1, 1000);
+camera.position.z = {cam_dist};
+const renderer = new THREE.WebGLRenderer({{antialias:true}});
+renderer.setSize(400, 400);
+document.getElementById('c').appendChild(renderer.domElement);
+const g = new THREE.BufferGeometry();
+const verts = new Float32Array(pts.flat());
+g.setAttribute('position', new THREE.BufferAttribute(verts, 3));
+const m = new THREE.PointsMaterial({{size:2,color:0x0080ff}});
+const points = new THREE.Points(g, m);
+scene.add(points);
+function animate(){
+  requestAnimationFrame(animate);
+  points.rotation.y += 0.01;
+  renderer.render(scene, camera);
+}
+animate();
+</script>
+"""
 
 
 @st.cache_data(ttl=3600)
@@ -40,27 +87,40 @@ elif selected:
 
 if file_path:
     nodes, elements, node_sets, elem_sets, materials = load_cdb(file_path)
-    st.write("Nodos:", len(nodes))
-    st.write("Elementos:", len(elements))
-    st.write("Conjuntos de nodos:", len(node_sets))
-    st.write("Conjuntos de elementos:", len(elem_sets))
-    st.write("Materiales:", len(materials))
+    info_tab, preview_tab = st.tabs(["Información", "Vista 3D"])
 
-    if st.button("Generar input deck"):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            rad_path = Path(tmpdir) / "model_0000.rad"
-            mesh_path = Path(tmpdir) / "mesh.inp"
-            write_rad(
-                nodes,
-                elements,
-                str(rad_path),
-                mesh_inc=str(mesh_path),
-                node_sets=node_sets,
-                elem_sets=elem_sets,
-                materials=materials,
-            )
-            st.success("Ficheros generados en directorio temporal")
-            lines = mesh_path.read_text().splitlines()[:20]
-            st.code("\n".join(lines))
+    with info_tab:
+        st.write("Nodos:", len(nodes))
+        st.write("Elementos:", len(elements))
+        st.write("Conjuntos de nodos:", len(node_sets))
+        for name, nids in node_sets.items():
+            st.write(f"- {name}: {len(nids)} nodos")
+        st.write("Conjuntos de elementos:", len(elem_sets))
+        for name, eids in elem_sets.items():
+            st.write(f"- {name}: {len(eids)} elementos")
+        st.write("Materiales:")
+        for mid, props in materials.items():
+            st.write(f"- ID {mid}: {props}")
+
+        if st.button("Generar input deck"):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                rad_path = Path(tmpdir) / "model_0000.rad"
+                mesh_path = Path(tmpdir) / "mesh.inp"
+                write_rad(
+                    nodes,
+                    elements,
+                    str(rad_path),
+                    mesh_inc=str(mesh_path),
+                    node_sets=node_sets,
+                    elem_sets=elem_sets,
+                    materials=materials,
+                )
+                st.success("Ficheros generados en directorio temporal")
+                lines = mesh_path.read_text().splitlines()[:20]
+                st.code("\n".join(lines))
+
+    with preview_tab:
+        html = viewer_html(nodes)
+        st.components.v1.html(html, height=420)
 else:
     st.info("Sube o selecciona un archivo .cdb")


### PR DESCRIPTION
## Summary
- extend dashboard with new `viewer_html` util that renders nodes using Three.js
- show node and element sets, plus material properties in an information tab
- add a new tab with a simple 3D mesh preview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b35daf48c8327bd181e52f05fb8bf