### PR TITLE
FIX: expand ANSYS CMBLOCK ranges

### DIFF
--- a/cdb2rad/parser.py
+++ b/cdb2rad/parser.py
@@ -121,7 +121,14 @@ def parse_cdb(filepath: str) -> Tuple[
                     break
                 for part in ln.split():
                     try:
-                        values.append(int(part))
+                        val = int(part)
+                        if val < 0 and values:
+                            start = values.pop()
+                            end = abs(val)
+                            step = 1 if start <= end else -1
+                            values.extend(range(start, end + step, step))
+                        else:
+                            values.append(val)
                     except ValueError:
                         pass
                 i += 1

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -12,6 +12,10 @@ def test_parse_cdb():
     assert len(elements) == 2479
     assert "BALL" in elem_sets
     assert "TARGET" in elem_sets
+    assert elem_sets["BALL"][0] == 1
+    assert elem_sets["BALL"][-1] == 715
+    assert elem_sets["TARGET"][0] == 918
+    assert elem_sets["TARGET"][-1] == 2681
 
 
 def test_write_mesh(tmp_path):


### PR DESCRIPTION
## Summary
- expand negative values in `CMBLOCK` to element ranges
- validate range parsing in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b39fbdbb0832782dd6643e14cb46a