### PR TITLE
Add element type summary to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,12 @@ pytest -q
 ## Interfaz web
 
 Se incluye una pequeña interfaz en Streamlit para cargar un `.cdb`, visualizar
-el número de nodos y elementos y generar los ficheros ``mesh.inp`` y
+el número y tipo de elementos y generar los ficheros ``mesh.inp`` y
 ``model_0000.rad`` de forma interactiva. Para ejecutarla:
 
 ```bash
 streamlit run src/dashboard/app.py
 ```
 
-Se puede subir un archivo propio o seleccionar ``data_files/model.cdb`` como
-ejemplo. Tras pulsar *Generar input deck* se muestran las primeras líneas de
-``mesh.inp``.
+Sube un archivo ``.cdb`` y pulsa *Generar input deck* para ver las primeras
+líneas de ``mesh.inp`` junto con un resumen de tipos de elemento.

--- a/cdb2rad/__init__.py
+++ b/cdb2rad/__init__.py
@@ -1,0 +1,13 @@
+"""Public API for cdb2rad."""
+
+from .parser import parse_cdb
+from .writer_inc import write_mesh_inp
+from .writer_rad import write_rad
+from .utils import element_summary
+
+__all__ = [
+    "parse_cdb",
+    "write_mesh_inp",
+    "write_rad",
+    "element_summary",
+]

--- a/cdb2rad/utils.py
+++ b/cdb2rad/utils.py
@@ -1,0 +1,51 @@
+"""Utility helpers for analyzing elements."""
+
+from typing import List, Tuple, Dict
+import json
+from pathlib import Path
+
+
+def element_summary(
+    elements: List[Tuple[int, int, List[int]]],
+    mapping_file: str | None = None,
+) -> tuple[Dict[int, int], Dict[str, int]]:
+    """Return counts by Ansys ``etype`` and Radioss keyword.
+
+    Parameters
+    ----------
+    elements : list of tuples
+        Sequence ``(eid, etype, node_ids)`` from :func:`parse_cdb`.
+    mapping_file : str, optional
+        Path to ``mapping.json``. When ``None`` uses the file next to this
+        module.
+
+    Returns
+    -------
+    tuple
+        ``(etype_counts, keyword_counts)`` dictionaries.
+    """
+    if mapping_file is None:
+        mapping_path = Path(__file__).with_name("mapping.json")
+    else:
+        mapping_path = Path(mapping_file)
+
+    with open(mapping_path, "r", encoding="utf-8") as mf:
+        mapping: Dict[str, str] = json.load(mf)
+
+    etype_counts: Dict[int, int] = {}
+    keyword_counts: Dict[str, int] = {}
+    for _eid, etype, nids in elements:
+        etype_counts[etype] = etype_counts.get(etype, 0) + 1
+        key = mapping.get(str(etype))
+        if not key:
+            if len(nids) in (4, 3):
+                key = "SHELL"
+            elif len(nids) in (8, 20):
+                key = "BRICK"
+            elif len(nids) in (4, 10):
+                key = "TETRA"
+            else:
+                key = "UNKNOWN"
+        keyword_counts[key] = keyword_counts.get(key, 0) + 1
+
+    return etype_counts, keyword_counts

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -83,9 +83,6 @@ if logo_path.exists():
     st.image(str(logo_path), width=150)
 
 uploaded = st.file_uploader("Subir archivo .cdb", type="cdb")
-example_dir = Path("data_files")
-examples = [p.name for p in example_dir.glob("*.cdb")]
-selected = st.selectbox("o escoger ejemplo", [""] + examples)
 
 file_path = None
 if uploaded is not None:
@@ -93,8 +90,6 @@ if uploaded is not None:
     tmp.write(uploaded.getvalue())
     tmp.close()
     file_path = tmp.name
-elif selected:
-    file_path = str(example_dir / selected)
 
 if file_path:
     nodes, elements, node_sets, elem_sets, materials = load_cdb(file_path)
@@ -103,6 +98,14 @@ if file_path:
     with info_tab:
         st.write("Nodos:", len(nodes))
         st.write("Elementos:", len(elements))
+        from cdb2rad.utils import element_summary
+        etype_counts, kw_counts = element_summary(elements)
+        st.write("Tipos de elemento (CDB):")
+        for et, cnt in sorted(etype_counts.items()):
+            st.write(f"- Tipo {et}: {cnt} elementos")
+        st.write("Tipos en Radioss:")
+        for kw, cnt in kw_counts.items():
+            st.write(f"- {kw}: {cnt}")
         st.write("Conjuntos de nodos:", len(node_sets))
         for name, nids in node_sets.items():
             st.write(f"- {name}: {len(nids)} nodos")
@@ -127,6 +130,9 @@ if file_path:
                     materials=materials,
                 )
                 st.success("Ficheros generados en directorio temporal")
+                st.write("Resumen de elementos traducidos:")
+                for kw, cnt in kw_counts.items():
+                    st.write(f"- {kw}: {cnt}")
                 lines = mesh_path.read_text().splitlines()[:20]
                 st.code("\n".join(lines))
 
@@ -139,4 +145,4 @@ if file_path:
             )
         st.components.v1.html(html, height=420)
 else:
-    st.info("Sube o selecciona un archivo .cdb")
+    st.info("Sube un archivo .cdb")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -2,6 +2,7 @@ import os
 from cdb2rad.parser import parse_cdb
 from cdb2rad.writer_inc import write_mesh_inp
 from cdb2rad.writer_rad import write_rad
+from cdb2rad.utils import element_summary
 
 DATA = os.path.join(os.path.dirname(__file__), '..', 'data', 'model.cdb')
 
@@ -16,6 +17,13 @@ def test_parse_cdb():
     assert elem_sets["BALL"][-1] == 715
     assert elem_sets["TARGET"][0] == 918
     assert elem_sets["TARGET"][-1] == 2681
+
+
+def test_element_summary():
+    _, elements, _, _, _ = parse_cdb(DATA)
+    etype_counts, kw_counts = element_summary(elements)
+    assert sum(kw_counts.values()) == len(elements)
+    assert kw_counts["BRICK"] > 0
 
 
 def test_write_mesh(tmp_path):


### PR DESCRIPTION
## Summary
- show element type summary in Streamlit dashboard
- expose API helper `element_summary`
- display translated element summary after generating input deck
- remove example selector from dashboard
- document new dashboard behaviour
- add tests for element summary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b4b66a248832784fce16171c11cc4