### PR TITLE
Set dashboard background to black

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -93,7 +93,8 @@ SDEA_DARK = "#1B1825"
 style = f"""
 <style>
 .stApp {{
-    background-color: #f5f5f5;
+    background-color: #000000;
+    color: white;
 }}
 .sdea-header {{
     background-color: {SDEA_DARK};


### PR DESCRIPTION
## Summary
- tweak Streamlit dashboard theme so the background is black with white text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bc417cf748327b5ef0dad0c85cb8d