### PR TITLE
Add surface rendering in dashboard viewer

### DIFF
--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -10,3 +10,4 @@ def test_viewer_html_basic():
     html = viewer_html(nodes, elements)
     assert 'OrbitControls' in html
     assert 'LineSegments' in html
+    assert 'MeshPhongMaterial' in html


### PR DESCRIPTION
## Summary
- enhance dashboard 3D viewer with optional triangular surfaces
- update viewer test to check for new mesh material

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bc5866bac83279d027cddf4f3ca01