### PR TITLE
Add RAD settings to dashboard

### DIFF
--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -18,6 +18,11 @@ def write_rad(
     node_sets: Dict[str, List[int]] | None = None,
     elem_sets: Dict[str, List[int]] | None = None,
     materials: Dict[int, Dict[str, float]] | None = None,
+    *,
+    thickness: float = DEFAULT_THICKNESS,
+    young: float = DEFAULT_E,
+    poisson: float = DEFAULT_NU,
+    density: float = DEFAULT_RHO,
 ) -> None:
     """Generate a minimal ``model_0000.rad`` file and the referenced mesh."""
 
@@ -38,16 +43,16 @@ def write_rad(
         f.write("/PART/1/1/1\n")
 
         f.write("/PROP/SHELL/1\n")
-        f.write(f"{DEFAULT_THICKNESS}\n")
+        f.write(f"{thickness}\n")
 
         if not materials:
             f.write("/MAT/LAW1/1\n")
-            f.write(f"{DEFAULT_E} {DEFAULT_NU} {DEFAULT_RHO}\n")
+            f.write(f"{young} {poisson} {density}\n")
         else:
             for mid, props in materials.items():
-                e = props.get("EX", DEFAULT_E)
-                nu = props.get("NUXY", DEFAULT_NU)
-                rho = props.get("DENS", DEFAULT_RHO)
+                e = props.get("EX", young)
+                nu = props.get("NUXY", poisson)
+                rho = props.get("DENS", density)
                 f.write(f"/MAT/LAW1/{mid}\n")
                 f.write(f"{e} {nu} {rho}\n")
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -52,7 +52,13 @@ def test_write_rad(tmp_path):
         node_sets=node_sets,
         elem_sets=elem_sets,
         materials=materials,
+        thickness=2.0,
+        young=1e5,
+        poisson=0.25,
+        density=7000.0,
     )
     content = rad.read_text()
     assert '/BEGIN' in content
     assert '/END' in content
+    assert '2.0' in content
+    assert '100000.0' in content


### PR DESCRIPTION
## Summary
- allow customizing material values in `write_rad`
- move RAD generation to new tab in dashboard with settings inputs
- test parameterized `write_rad`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bca0c91f48327805dd253f0ee629f