### PR TITLE
Add header and update OpenRadioss setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,21 @@ Después se puede ejecutar OpenRadioss sobre el fichero generado:
 
 ```bash
 python scripts/run_all.py data_files/model.cdb --rad model.rad \
-    --exec openradioss_bin/exec/starter_linux64_gf
+    --exec openradioss_bin/OpenRadioss/exec/starter_linux64_gf
+```
+
+Antes de ejecutar es necesario definir dos variables de entorno para que los
+binarios de OpenRadioss encuentren las bibliotecas y ficheros de configuración:
+
+```bash
+export LD_LIBRARY_PATH=$PWD/openradioss_bin/OpenRadioss/extlib/hm_reader/linux64
+export RAD_CFG_PATH=$PWD/openradioss_bin/OpenRadioss/hm_cfg_files
+```
+
+Con estas variables se puede lanzar el *starter* directamente:
+
+```bash
+openradioss_bin/OpenRadioss/exec/starter_linux64_gf -i model.rad
 ```
 
 Para lanzar las pruebas:

--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -53,6 +53,7 @@ def write_rad(
     )
 
     with open(outfile, "w") as f:
+        f.write("#RADIOSS STARTER\n")
         f.write("/BEGIN\n")
         f.write(f"/INCLUDE \"{mesh_inc}\"\n")
 

--- a/scripts/download_openradioss.py
+++ b/scripts/download_openradioss.py
@@ -29,7 +29,8 @@ def download(url: str, path: Path) -> None:
 
 
 def main() -> None:
-    if (DEST / 'exec').exists():
+    exec_dir = DEST / 'OpenRadioss' / 'exec'
+    if exec_dir.exists():
         print('OpenRadioss already installed')
         return
     asset_url = latest_linux_asset()
@@ -43,6 +44,17 @@ def main() -> None:
         download(asset_url, zip_path)
         with zipfile.ZipFile(zip_path) as zf:
             zf.extractall(DEST)
+
+    for exe in (
+        'starter_linux64_gf',
+        'starter_linux64_gf_sp',
+        'engine_linux64_gf',
+        'engine_linux64_gf_sp',
+    ):
+        path = exec_dir / exe
+        if path.exists():
+            os.chmod(path, os.stat(path).st_mode | 0o111)
+
     print(f'OpenRadioss extracted to {DEST}')
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -65,6 +65,7 @@ def test_write_rad(tmp_path):
 
     )
     content = rad.read_text()
+    assert content.startswith('#RADIOSS STARTER')
     assert '/BEGIN' in content
     assert '/END' in content
     assert '2.0' in content


### PR DESCRIPTION
## Summary
- add `#RADIOSS STARTER` line in starter writer
- mark downloaded OpenRadioss binaries as executable
- document required environment variables
- check header in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c3308a5308327a18a00a055408f9e