### PR TITLE
Fix run_all output path and update starter header

### DIFF
--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -55,10 +55,15 @@ def write_rad(
     with open(outfile, "w") as f:
         f.write("#RADIOSS STARTER\n")
         f.write("/BEGIN\n")
+        f.write(f"{runname}\n")
+        f.write("     2024         0\n")
+        f.write("                  kg                  mm                   s\n")
+        f.write("                  kg                  mm                   s\n")
         f.write(f"/INCLUDE \"{mesh_inc}\"\n")
 
         f.write("/PART/1\n")
-        f.write("/PART/1/1/1\n")
+        f.write("Part1\n")
+        f.write("1 1 0\n")
 
         f.write("/PROP/SHELL/1\n")
         f.write(f"{thickness}\n")

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -44,6 +44,7 @@ def main() -> None:
             nodes,
             elements,
             args.rad,
+            mesh_inc=args.inc or "mesh.inp",
             node_sets=node_sets,
             elem_sets=elem_sets,
             materials=materials,


### PR DESCRIPTION
## Summary
- pass `--inc` path to writer when generating `.rad`
- add missing header lines in `writer_rad`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c35e425948327ab60f361705e56d3