### PR TITLE
Add Radioss test setup and integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,20 @@ Para lanzar las pruebas:
 pytest -q
 ```
 
+### Entorno automático
+
+Para recrear el entorno de pruebas siguiendo las instrucciones de
+[HOWTO](https://github.com/OpenRadioss/OpenRadioss/blob/main/HOWTO.md) se ha
+añadido el script ``scripts/setup_test_env.py``. Ejecuta la creación del
+``virtualenv`` y descarga la última versión de OpenRadioss:
+
+```bash
+python scripts/setup_test_env.py
+```
+
+Al terminar, se muestran las variables de entorno necesarias para ejecutar el
+``starter`` y se pueden lanzar las pruebas con ``pytest -q``.
+
 ## Interfaz web
 
 Se incluye una pequeña interfaz en Streamlit para cargar un `.cdb`, visualizar

--- a/scripts/setup_test_env.py
+++ b/scripts/setup_test_env.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Prepare virtual environment and download OpenRadioss for testing."""
+from __future__ import annotations
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> None:
+    create = ROOT / 'scripts' / 'create_venv.py'
+    download = ROOT / 'scripts' / 'download_openradioss.py'
+
+    # create virtual environment if needed
+    if not (ROOT / '.venv').exists():
+        subprocess.run([sys.executable, str(create)], check=True)
+    else:
+        print('Virtual environment already exists')
+
+    # download OpenRadioss binaries
+    subprocess.run([sys.executable, str(download)], check=True)
+
+    ld = ROOT / 'openradioss_bin' / 'OpenRadioss' / 'extlib' / 'hm_reader' / 'linux64'
+    cfg = ROOT / 'openradioss_bin' / 'OpenRadioss' / 'hm_cfg_files'
+
+    print('\nSet the following variables before running the starter:')
+    print(f'export LD_LIBRARY_PATH={ld}')
+    print(f'export RAD_CFG_PATH={cfg}')
+    print('\nThen run `pytest -q` to execute the tests.')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_openradioss_run.py
+++ b/tests/test_openradioss_run.py
@@ -1,0 +1,22 @@
+import os
+import subprocess
+from pathlib import Path
+import pytest
+from cdb2rad.parser import parse_cdb
+from cdb2rad.writer_rad import write_rad
+
+DATA = Path(__file__).resolve().parents[1] / 'data' / 'model.cdb'
+EXEC = Path(__file__).resolve().parents[1] / 'openradioss_bin' / 'OpenRadioss' / 'exec' / 'starter_linux64_gf'
+LIBDIR = Path(__file__).resolve().parents[1] / 'openradioss_bin' / 'OpenRadioss' / 'extlib' / 'hm_reader' / 'linux64'
+CFGDIR = Path(__file__).resolve().parents[1] / 'openradioss_bin' / 'OpenRadioss' / 'hm_cfg_files'
+
+@pytest.mark.skipif(not EXEC.exists(), reason="OpenRadioss binary not installed")
+def test_run_starter(tmp_path):
+    nodes, elements, node_sets, elem_sets, mats = parse_cdb(str(DATA))
+    rad = tmp_path / 'model_0000.rad'
+    write_rad(nodes, elements, str(rad), node_sets=node_sets, elem_sets=elem_sets, materials=mats)
+    env = os.environ.copy()
+    env['LD_LIBRARY_PATH'] = str(LIBDIR)
+    env['RAD_CFG_PATH'] = str(CFGDIR)
+    result = subprocess.run([str(EXEC), '-i', str(rad)], env=env, capture_output=True, text=True)
+    assert 'OpenRadioss Starter' in result.stdout


### PR DESCRIPTION
## Summary
- add `setup_test_env.py` script to automate environment preparation
- document the new script in README
- add regression test that runs the starter on a generated `.rad`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c3b1af5dc8327a01292121975afd1