### PR TITLE
Fix rad include syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Ansys a un *input deck* compatible con OpenRadioss.
 3. Genera un fichero ``mesh.inp`` con ``/NODE`` y bloques de elementos
    derivados de ``mapping.json`` (``/SHELL``, ``/BRICK``, ``/TETRA``...). Las
    selecciones y los materiales se exportan en formato Radioss.
-4. Crea ``model_0000.rad`` que incluye ``mesh.inp`` y define propiedades,
+4. Crea ``model_0000.rad`` que referencia ``mesh.inp`` mediante ``#include`` y define propiedades,
    materiales, condiciones de contorno y ejemplos de contacto y carga.
 
 ## Entrada requerida

--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -59,7 +59,8 @@ def write_rad(
         f.write("     2024         0\n")
         f.write("                  kg                  mm                   s\n")
         f.write("                  kg                  mm                   s\n")
-        f.write(f"/INCLUDE \"{mesh_inc}\"\n")
+        # radioss 2024 uses `#include` for file references
+        f.write(f"#include {mesh_inc}\n")
 
         f.write("/PART/1\n")
         f.write("Part1\n")
@@ -79,17 +80,9 @@ def write_rad(
                 f.write(f"/MAT/LAW1/{mid}\n")
                 f.write(f"{e} {nu} {rho}\n")
 
-        f.write("/BOUNDARY/BCS/1\n")
+        f.write("/BCS/1\n")
         f.write("1 1 1 1 1 1\n")
 
-        f.write("/LOAD/PBLAST/1\n")
-        f.write("0.0 0.0 0.0\n")
-
-        f.write("/INTER/TYPE7/1\n")
-        f.write("0 0 0.0 0.0 0.0\n")
-
-        f.write("/SENSOR/SPRING/1\n")
-        f.write("0.0\n")
 
         # Basic engine control cards
         f.write(f"/RUN/{runname}/1/\n")

--- a/data/example.rad
+++ b/data/example.rad
@@ -1,5 +1,5 @@
 /BEGIN
-/INCLUDE "mesh.inp"
+#include mesh.inp
 /PART/1
 /PROP/1
 /MAT/1


### PR DESCRIPTION
## Summary
- use `#include` in starter file
- drop unused cards and simplify boundary syntax
- update README and example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c3b75263883279ea6fbe0e5a2588d