### PR TITLE
Switch mesh include file extension to .inc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This repository implements a lightweight **translator between Ansys `.cdb` files
 
 The agent’s task is to help maintain and extend a Python program that takes as input a `.cdb` file exported from Ansys Mechanical or MAPDL, and produces:
 
-1. A **Radioss input mesh file** (`mesh.inp`) containing:
+1. A **Radioss input mesh file** (`mesh.inc`) containing:
    - `/NODE`, `/SHELL`, `/BRICK` definitions
    - Formatted in **Radioss Block Input Syntax** (not Abaqus)
 
@@ -33,8 +33,8 @@ The output `.rad` file is expected to run **directly in OpenRadioss**.
   EBLOCK → element ID, type, material ID, connectivity
 
 ᾞa Output formats
-1. mesh.inp (Radioss-compatible)
-This is not Abaqus .inp — it’s a Radioss-style mesh include file.
+1. mesh.inc (Radioss-compatible)
+This is not Abaqus .inc — it’s a Radioss-style mesh include file.
 
 Example:
 ```
@@ -50,7 +50,7 @@ Example:
 Includes structural setup and pointers to mesh:
 ```
 /BEGIN
-/INCLUDE "mesh.inp"
+/INCLUDE "mesh.inc"
 /PART/1/1/1
 /PROP/SHELL/1 0.8 0
 /MAT/LAW1/1 210000 0.3 7800
@@ -61,7 +61,7 @@ Includes structural setup and pointers to mesh:
 ```
 cdb2rad/
 ├── parser.py         # Reads .cdb → (nodes, elements)
-├── writer_inc.py     # Generates mesh.inp from nodes/elements
+├── writer_inc.py     # Generates mesh.inc from nodes/elements
 ├── writer_rad.py     # Assembles model_0000.rad (starter)
 ├── mapping.json      # Maps Ansys ETYPES to Radioss keywords
 
@@ -74,7 +74,7 @@ Codex must be able to:
 - Parse NBLOCK → dictionary of {node_id: [x, y, z]}
 - Parse EBLOCK → list of (eid, etype, [n1, n2, …])
 - Auto-map element type to Radioss (e.g., 4-noded → /SHELL, 8-noded → /BRICK)
-- Generate a valid mesh.inp file in Radioss block syntax
+- Generate a valid mesh.inc file in Radioss block syntax
 - Assemble a starter file (model_0000.rad) with structure and references
 - Expand logic to support:
   - /INTER/TYPE7 contact

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Ansys a un *input deck* compatible con OpenRadioss.
 1. Lee bloques ``NBLOCK`` y ``EBLOCK`` de un ``.cdb``.
 2. Detecta selecciones nombradas (``CMBLOCK``) y datos de material
    (``MPDATA``).
-3. Genera un fichero ``mesh.inp`` con ``/NODE`` y bloques de elementos
+3. Genera un fichero ``mesh.inc`` con ``/NODE`` y bloques de elementos
    derivados de ``mapping.json`` (``/SHELL``, ``/BRICK``, ``/TETRA``...). Las
    selecciones y los materiales se exportan en formato Radioss.
-4. Crea ``model_0000.rad`` que referencia ``mesh.inp`` mediante ``#include`` y define propiedades,
+4. Crea ``model_0000.rad`` que referencia ``mesh.inc`` mediante ``#include`` y define propiedades,
    materiales, condiciones de contorno y ejemplos de contacto y carga.
 
 ## Entrada requerida
@@ -22,13 +22,13 @@ ejemplos de la documentación.
 
 ## Salida generada
 
- - ``mesh.inp``: definición de nodos y elementos.
+ - ``mesh.inc``: definición de nodos y elementos.
  - ``model_0000.rad``: fichero de inicio con propiedades, material y BCs.
 
 ## Ejemplo de uso
 
 ```bash
-python scripts/run_all.py data_files/model.cdb --inc mesh.inp --rad model_0000.rad
+python scripts/run_all.py data_files/model.cdb --inc mesh.inc --rad model_0000.rad
 ```
 
 ### Entorno virtual y OpenRadioss
@@ -85,7 +85,7 @@ Al terminar, se muestran las variables de entorno necesarias para ejecutar el
 ## Interfaz web
 
 Se incluye una pequeña interfaz en Streamlit para cargar un `.cdb`, visualizar
-el número y tipo de elementos y generar los ficheros ``mesh.inp`` y
+el número y tipo de elementos y generar los ficheros ``mesh.inc`` y
 ``model_0000.rad`` de forma interactiva. Para ejecutarla:
 
 ```bash
@@ -98,12 +98,12 @@ ejemplo. La interfaz cuenta con cuatro pestañas principales:
 - **Información** resumen de nodos y elementos.
 - **Vista 3D** previsualización ligera de la malla.
 
-- **Generar INP** permite crear ``mesh.inp`` y muestra sus primeras líneas. \
+-- **Generar INC** permite crear ``mesh.inc`` y muestra sus primeras líneas. \
   Incluye casillas para decidir si exportar las selecciones nombradas y los
   materiales.
 
 - **Generar RAD** para introducir parámetros de cálculo y obtener
   ``model_0000.rad``.
 
-Tras pulsar *Generar .inp* o *Generar .rad* se muestran las primeras líneas de
+Tras pulsar *Generar .inc* o *Generar .rad* se muestran las primeras líneas de
 los ficheros generados.

--- a/cdb2rad/__init__.py
+++ b/cdb2rad/__init__.py
@@ -1,13 +1,13 @@
 """Public API for cdb2rad."""
 
 from .parser import parse_cdb
-from .writer_inc import write_mesh_inp
+from .writer_inc import write_mesh_inc
 from .writer_rad import write_rad
 from .utils import element_summary
 
 __all__ = [
     "parse_cdb",
-    "write_mesh_inp",
+    "write_mesh_inc",
     "write_rad",
     "element_summary",
 ]

--- a/cdb2rad/writer_inc.py
+++ b/cdb2rad/writer_inc.py
@@ -1,11 +1,11 @@
-"""Utilities to write ``mesh.inp`` include files in Radioss format."""
+"""Utilities to write ``mesh.inc`` include files in Radioss format."""
 
 from typing import Dict, List, Tuple
 import json
 from pathlib import Path
 
 
-def write_mesh_inp(
+def write_mesh_inc(
     nodes: Dict[int, List[float]],
     elements: List[Tuple[int, int, List[int]]],
     outfile: str,
@@ -14,7 +14,7 @@ def write_mesh_inp(
     elem_sets: Dict[str, List[int]] | None = None,
     materials: Dict[int, Dict[str, float]] | None = None,
 ) -> None:
-    """Write ``mesh.inp`` with element blocks derived from ``mapping.json``.
+    """Write ``mesh.inc`` with element blocks derived from ``mapping.json``.
 
     Optionally, node and element sets (from CMBLOCK) and basic material
     properties can be written for later use in the starter file.

--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -2,7 +2,7 @@
 
 from typing import Dict, List, Tuple
 
-from .writer_inc import write_mesh_inp
+from .writer_inc import write_mesh_inc
 
 DEFAULT_THICKNESS = 1.0
 DEFAULT_E = 210000.0
@@ -19,7 +19,7 @@ def write_rad(
     nodes: Dict[int, List[float]],
     elements: List[Tuple[int, int, List[int]]],
     outfile: str,
-    mesh_inc: str = "mesh.inp",
+    mesh_inc: str = "mesh.inc",
     node_sets: Dict[str, List[int]] | None = None,
     elem_sets: Dict[str, List[int]] | None = None,
     materials: Dict[int, Dict[str, float]] | None = None,
@@ -43,7 +43,7 @@ def write_rad(
     controls.
     """
 
-    write_mesh_inp(
+    write_mesh_inc(
         nodes,
         elements,
         mesh_inc,

--- a/data/example.rad
+++ b/data/example.rad
@@ -1,5 +1,5 @@
 /BEGIN
-#include mesh.inp
+#include mesh.inc
 /PART/1
 /PROP/1
 /MAT/1

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -10,7 +10,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from cdb2rad.parser import parse_cdb
-from cdb2rad.writer_inc import write_mesh_inp
+from cdb2rad.writer_inc import write_mesh_inc
 from cdb2rad.writer_rad import write_rad
 
 
@@ -18,20 +18,20 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Process .cdb file")
     parser.add_argument("cdb_file", help="Input .cdb file")
     parser.add_argument("--rad", dest="rad", help="Output .rad file")
-    parser.add_argument("--inc", dest="inc", help="Output mesh.inp file")
+    parser.add_argument("--inc", dest="inc", help="Output mesh.inc file")
     parser.add_argument("--exec", dest="exec_path", help="Run OpenRadioss starter after generation")
 
     args = parser.parse_args()
 
     if not args.rad and not args.inc:
         # default output names when none are provided
-        args.inc = "mesh.inp"
+        args.inc = "mesh.inc"
         args.rad = "model_0000.rad"
 
     nodes, elements, node_sets, elem_sets, materials = parse_cdb(args.cdb_file)
 
     if args.inc:
-        write_mesh_inp(
+        write_mesh_inc(
             nodes,
             elements,
             args.inc,
@@ -44,7 +44,7 @@ def main() -> None:
             nodes,
             elements,
             args.rad,
-            mesh_inc=args.inc or "mesh.inp",
+            mesh_inc=args.inc or "mesh.inc",
             node_sets=node_sets,
             elem_sets=elem_sets,
             materials=materials,

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -22,7 +22,7 @@ if root_path not in sys.path:
 
 from cdb2rad.parser import parse_cdb
 from cdb2rad.writer_rad import write_rad
-from cdb2rad.writer_inc import write_mesh_inp
+from cdb2rad.writer_inc import write_mesh_inc
 
 
 MAX_EDGES = 10000
@@ -259,7 +259,7 @@ if file_path:
     info_tab, preview_tab, inp_tab, rad_tab = st.tabs([
         "Información",
         "Vista 3D",
-        "Generar INP",
+        "Generar INC",
         "Generar RAD",
     ])
 
@@ -295,15 +295,15 @@ if file_path:
         st.components.v1.html(html, height=420)
 
     with inp_tab:
-        st.subheader("Generar mesh.inp")
+        st.subheader("Generar mesh.inc")
 
         use_sets = st.checkbox("Incluir name selections", value=True)
         use_mats = st.checkbox("Incluir materiales", value=True)
 
-        if st.button("Generar .inp"):
+        if st.button("Generar .inc"):
             with tempfile.TemporaryDirectory() as tmpdir:
-                inp_path = Path(tmpdir) / "mesh.inp"
-                write_mesh_inp(
+                inp_path = Path(tmpdir) / "mesh.inc"
+                write_mesh_inc(
                     nodes,
                     elements,
                     str(inp_path),
@@ -337,7 +337,7 @@ if file_path:
         if st.button("Generar .rad"):
             with tempfile.TemporaryDirectory() as tmpdir:
                 rad_path = Path(tmpdir) / "model_0000.rad"
-                mesh_path = Path(tmpdir) / "mesh.inp"
+                mesh_path = Path(tmpdir) / "mesh.inc"
                 write_rad(
                     nodes,
                     elements,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,6 @@
 import os
 from cdb2rad.parser import parse_cdb
-from cdb2rad.writer_inc import write_mesh_inp
+from cdb2rad.writer_inc import write_mesh_inc
 from cdb2rad.writer_rad import write_rad
 from cdb2rad.utils import element_summary
 
@@ -28,8 +28,8 @@ def test_element_summary():
 
 def test_write_mesh(tmp_path):
     nodes, elements, node_sets, elem_sets, materials = parse_cdb(DATA)
-    out = tmp_path / 'mesh.inp'
-    write_mesh_inp(
+    out = tmp_path / 'mesh.inc'
+    write_mesh_inc(
         nodes,
         elements,
         str(out),
@@ -79,8 +79,8 @@ def test_write_rad(tmp_path):
 
 def test_write_mesh_without_sets_materials(tmp_path):
     nodes, elements, node_sets, elem_sets, materials = parse_cdb(DATA)
-    out = tmp_path / 'mesh_no_sets.inp'
-    write_mesh_inp(nodes, elements, str(out))
+    out = tmp_path / 'mesh_no_sets.inc'
+    write_mesh_inc(nodes, elements, str(out))
     content = out.read_text()
     assert '/GRNOD' not in content
     assert '/SET/EL' not in content


### PR DESCRIPTION
## Summary
- change mesh file name to `mesh.inc` in documentation and code
- rename `write_mesh_inp` -> `write_mesh_inc`
- update CLI defaults and Streamlit UI for the new extension
- adjust tests to match the new output name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c3fa5dbb88327a04587185d41b392