### PR TITLE
DOC: guía rápida para depurar ficheros .rad

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ Codex must be able to:
 - OpenRadioss GitHub: <https://github.com/OpenRadioss/OpenRadioss>
 - Radioss Examples (Starter/Engine): <https://github.com/OpenRadioss/OpenRadioss-examples>
 - OpenRadioss User Documentation: <https://openradioss.atlassian.net/wiki/spaces/OPENRADIOSS/pages/4816906/OpenRadioss+User+Documentation>
+- Overview of the Input Reference Guide: <https://help.altair.com/hwsolvers/rad/topics/solvers/rad/overview_ref_guide_rad_c.htm>
 
 ## ✅ Development style guide
 All modules should use pure Python 3.10+, no external dependencies.
@@ -106,6 +107,7 @@ If Codex is asked to:
 - Extend writer modules: ensure all new syntax is compliant with Radioss Block.
 - Add material/BC/contact support: use valid Radioss keywords from official docs.
 - Refactor parser: maintain robustness and backward compatibility with .cdb structure.
+- When debugging ``.rad`` files, consult the [Input Reference Guide](https://help.altair.com/hwsolvers/rad/topics/solvers/rad/overview_ref_guide_rad_c.htm) for the exact block syntax and available keywords.
 
 This project serves as a bridge between the Ansys modeling world and open-source Radioss simulation. Codex should support the user in maintaining this pipeline and expanding it into a full Radioss preprocessor.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,25 @@ ejemplos de la documentación.
  - ``mesh.inc``: definición de nodos y elementos.
  - ``model_0000.rad``: fichero de inicio con propiedades, material y BCs.
 
+## Configuración del ``.rad``
+
+El *starter* ``model_0000.rad`` sigue la sintaxis por bloques de Radioss. Un
+fichero mínimo contiene:
+
+```text
+/BEGIN
+/INCLUDE "mesh.inc"
+/PART
+...   # definición de propiedades y materiales
+/END
+```
+
+Cada bloque está descrito en detalle en la guía oficial de comandos de
+Radioss. Para depurar y ampliar estos ficheros se recomienda consultar el
+[Overview of the Input Reference Guide](https://help.altair.com/hwsolvers/rad/topics/solvers/rad/overview_ref_guide_rad_c.htm).
+En ella se explica el formato, las palabras clave disponibles y la estructura
+del ``starter`` y los ficheros ``engine``.
+
 ## Ejemplo de uso
 
 ```bash


### PR DESCRIPTION
## Summary
- documentar los bloques mínimos que forman un `.rad`
- enlazar la guía de referencia de Altair en README y AGENTS

## Testing
- `pip install -q -r requirements.txt`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c436508608327a65cde60e861c5a3