### PR TITLE
Add impact material support

### DIFF
--- a/cdb2rad/writer_inc.py
+++ b/cdb2rad/writer_inc.py
@@ -71,8 +71,19 @@ def write_mesh_inc(
 
         if materials:
             for mid, props in materials.items():
+                law = props.get("LAW", "LAW1").upper()
                 e = props.get("EX", 210000.0)
                 nu = props.get("NUXY", 0.3)
                 rho = props.get("DENS", 7800.0)
-                f.write(f"\n/MAT/LAW1/{mid}\n")
-                f.write(f"{e} {nu} {rho}\n")
+                if law in ("LAW2", "JOHNSON_COOK"):
+                    a = props.get("A", 0.0)
+                    b = props.get("B", 0.0)
+                    n_val = props.get("N", 0.0)
+                    c = props.get("C", 0.0)
+                    eps0 = props.get("EPS0", 1.0)
+                    f.write(f"\n/MAT/LAW2/{mid}\n")
+                    f.write(f"{rho} {e} {nu}\n")
+                    f.write(f"{a} {b} {n_val} {c} {eps0}\n")
+                else:
+                    f.write(f"\n/MAT/LAW1/{mid}\n")
+                    f.write(f"{e} {nu} {rho}\n")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -77,6 +77,35 @@ def test_write_rad(tmp_path):
     assert '0.0001' in content
 
 
+def test_write_rad_extra_materials(tmp_path):
+    nodes, elements, node_sets, elem_sets, materials = parse_cdb(DATA)
+    extra = {
+        99: {
+            'LAW': 'LAW2',
+            'EX': 1e5,
+            'NUXY': 0.3,
+            'DENS': 7800.0,
+            'A': 200.0,
+            'B': 400.0,
+            'N': 0.5,
+            'C': 0.01,
+            'EPS0': 1.0,
+        }
+    }
+    rad = tmp_path / 'model_extra.rad'
+    write_rad(
+        nodes,
+        elements,
+        str(rad),
+        node_sets=node_sets,
+        elem_sets=elem_sets,
+        materials=materials,
+        extra_materials=extra,
+    )
+    txt = rad.read_text()
+    assert '/MAT/LAW2/99' in txt
+
+
 def test_write_mesh_without_sets_materials(tmp_path):
     nodes, elements, node_sets, elem_sets, materials = parse_cdb(DATA)
     out = tmp_path / 'mesh_no_sets.inc'


### PR DESCRIPTION
## Summary
- extend `write_rad` and `write_mesh_inc` to handle LAW2 (Johnson-Cook)
- allow adding impact materials in the Streamlit dashboard
- generate `.rad` with optional CDB or impact materials
- test `write_rad` with extra materials

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c47d8c0948327bfabee466c402c82