### PR TITLE
Show temporary path for .rad in dashboard

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -409,7 +409,9 @@ if file_path:
                     dt_ratio=dt_ratio,
 
                 )
-                st.success("Ficheros generados en directorio temporal")
+                st.success(
+                    f"Ficheros generados en directorio temporal: {rad_path.parent}"
+                )
                 lines = rad_path.read_text().splitlines()[:20]
                 st.code("\n".join(lines))
 


### PR DESCRIPTION
## Summary
- update Streamlit message to display temporary directory for generated `.rad`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c4d787c28832796693dc18f5df681