### PR TITLE
Show .rad path

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -409,7 +409,9 @@ if file_path:
                     dt_ratio=dt_ratio,
 
                 )
-                st.success("Ficheros generados en directorio temporal")
+                st.success(
+                    f"Ficheros generados en directorio temporal: {rad_path}"
+                )
                 lines = rad_path.read_text().splitlines()[:20]
                 st.code("\n".join(lines))
 


### PR DESCRIPTION
## Summary
- show the path to the temporary `.rad` file in the dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c4e599ed88327af5931f7bc9141d8