### PR TITLE
FEAT: dashboard output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,5 @@ archivo.
 
 Tras pulsar *Generar .inc* o *Generar .rad* se muestran las primeras líneas de
 los ficheros generados.
+Cada pestaña permite elegir el directorio de salida y el nombre (sin extensión)
+del archivo para guardar fácilmente los resultados.


### PR DESCRIPTION
## Summary
- add output directory and file name fields to INC/RAD generation
- allow ZIP export path choice
- document new dashboard options

## Testing
- `flake8`
- `mypy .`
- `bandit -r .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c51734e48832784c887310c9f9f6a