### PR TITLE
Add gravity option in Radioss writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ Se incluyen casillas opcionales para **sobrescribir** los archivos
 - **RAD limpio (.rad)** genera ``minimal.rad`` para probar rápidamente ``mesh.inc``.
 
 La pestaña *Generar RAD* también permite definir condiciones de contorno
-(tarjetas ``/BCS``), contactos simples (``/INTER/TYPE2``) y velocidades
-iniciales (``/IMPVEL``) seleccionando las *name selections* de nodos en un
+(tarjetas ``/BCS``), contactos simples (``/INTER/TYPE2``), velocidades
+iniciales (``/IMPVEL``) y cargas de gravedad (``/GRAVITY``) seleccionando las *name selections* de nodos en un
 desplegable. Estos campos se pueden editar y añadir en el panel
 correspondiente antes de generar el archivo.
 

--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -44,13 +44,15 @@ def write_rad(
     boundary_conditions: List[Dict[str, object]] | None = None,
     interfaces: List[Dict[str, object]] | None = None,
     init_velocity: Dict[str, object] | None = None,
+    gravity: Dict[str, float] | None = None,
 
 ) -> None:
     """Generate ``model_0000.rad`` with optional solver controls.
 
     Parameters allow customizing material properties and basic engine
     settings such as final time, animation frequency and time-step
-    controls.
+    controls. Gravity loading can be specified via the ``gravity``
+    parameter.
     """
 
     all_mats: Dict[int, Dict[str, float]] = {}
@@ -166,6 +168,16 @@ def write_rad(
             f.write("Init_Vel_Nodes\n")
             for nid in nodes_v:
                 f.write(f"{nid:10d}\n")
+
+        if gravity:
+            g = gravity.get("g", 9.81)
+            nx = gravity.get("nx", 0.0)
+            ny = gravity.get("ny", 0.0)
+            nz = gravity.get("nz", -1.0)
+            comp = int(gravity.get("comp", 3))
+            f.write("/GRAVITY\n")
+            f.write(f"{comp} {g}\n")
+            f.write(f"{nx} {ny} {nz}\n")
 
         f.write("/END\n")
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -149,3 +149,11 @@ def test_write_rad_with_impvel(tmp_path):
     txt = rad.read_text()
     assert '/IMPVEL/1' in txt
 
+
+def test_write_rad_with_gravity(tmp_path):
+    nodes, elements, *_ = parse_cdb(DATA)
+    rad = tmp_path / 'grav.rad'
+    write_rad(nodes, elements, str(rad), gravity={'g': 9.81, 'nz': -1.0})
+    txt = rad.read_text()
+    assert '/GRAVITY' in txt
+


### PR DESCRIPTION
## Summary
- implement optional gravity block in `write_rad`
- document gravity control in README
- test gravity support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c5a2e07b0832789e00fc381cbcd7a