### PR TITLE
Remove example dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ el número y tipo de elementos y generar los ficheros ``mesh.inc`` y
 streamlit run src/dashboard/app.py
 ```
 
-Se puede subir un archivo propio o escoger ``data_files/model.cdb`` como
-ejemplo. La interfaz cuenta con cuatro pestañas principales:
+Se puede subir un archivo ``.cdb`` propio. La interfaz cuenta con cuatro
+pestañas principales:
 
 - **Información** resumen de nodos y elementos.
 - **Vista 3D** previsualización ligera de la malla.

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -241,9 +241,6 @@ with header:
     st.markdown("</div>", unsafe_allow_html=True)
 
 uploaded = st.file_uploader("Subir archivo .cdb", type="cdb")
-example_dir = Path("data_files")
-examples = [p.name for p in example_dir.glob("*.cdb")]
-selected = st.selectbox("o escoger ejemplo", [""] + examples)
 
 file_path = None
 if uploaded is not None:
@@ -251,8 +248,6 @@ if uploaded is not None:
     tmp.write(uploaded.getvalue())
     tmp.close()
     file_path = tmp.name
-elif selected:
-    file_path = str(example_dir / selected)
 
 if file_path:
     work_dir = st.text_input(


### PR DESCRIPTION
## Summary
- strip example selection from dashboard upload step
- clarify README instructions about uploading .cdb files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c59a4aa008327a4095684cebdd990