### PR TITLE
Add TYPE7 contact support

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,11 @@ Se incluyen casillas opcionales para **sobrescribir** los archivos
 - **RAD limpio (.rad)** genera ``minimal.rad`` para probar rápidamente ``mesh.inc``.
 
 La pestaña *Generar RAD* también permite definir condiciones de contorno
-(tarjetas ``/BCS``), contactos simples (``/INTER/TYPE2``), velocidades
-iniciales (``/IMPVEL``) y cargas de gravedad (``/GRAVITY``) seleccionando las *name selections* de nodos en un
-desplegable. Estos campos se pueden editar y añadir en el panel
-correspondiente antes de generar el archivo.
+(tarjetas ``/BCS``), contactos simples (``/INTER/TYPE2``) o generales
+(``/INTER/TYPE7``), velocidades iniciales (``/IMPVEL``) y cargas de
+gravedad (``/GRAVITY``) seleccionando las *name selections* de nodos en un
+desplegable. Estos campos se pueden editar y añadir en el panel correspondiente
+antes de generar el archivo.
 
 Tras pulsar *Generar .inc* o *Generar .rad* se muestran las primeras líneas de
 los ficheros generados.

--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -135,17 +135,30 @@ def write_rad(
 
         if interfaces:
             for idx, inter in enumerate(interfaces, start=1):
+                itype = inter.get("type", "TYPE2").upper()
                 s_nodes = inter.get("slave", [])
                 m_nodes = inter.get("master", [])
                 name = inter.get("name", f"INTER_{idx}")
                 fric = inter.get("fric", 0.0)
                 slave_id = 200 + idx
                 master_id = 300 + idx
-                f.write(f"/INTER/TYPE2/{idx}\n")
-                f.write(f"{name}\n")
-                f.write(f"{slave_id} {master_id}\n")
-                f.write("/FRICTION\n")
-                f.write(f"{fric}\n")
+
+                if itype == "TYPE7":
+                    gap = inter.get("gap", 0.0)
+                    stif = inter.get("stiff", 0.0)
+                    igap = inter.get("igap", 0)
+                    f.write(f"/INTER/TYPE7/{idx}\n")
+                    f.write(f"{name}\n")
+                    f.write(f"{slave_id} {master_id} {stif} {gap} {igap}\n")
+                    f.write("/FRICTION\n")
+                    f.write(f"{fric}\n")
+                else:
+                    f.write(f"/INTER/TYPE2/{idx}\n")
+                    f.write(f"{name}\n")
+                    f.write(f"{slave_id} {master_id}\n")
+                    f.write("/FRICTION\n")
+                    f.write(f"{fric}\n")
+
                 f.write(f"/GRNOD/NODE/{slave_id}\n")
                 f.write(f"{name}_slave\n")
                 for nid in s_nodes:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -157,3 +157,19 @@ def test_write_rad_with_gravity(tmp_path):
     txt = rad.read_text()
     assert '/GRAVITY' in txt
 
+
+def test_write_rad_with_type7_contact(tmp_path):
+    nodes, elements, *_ = parse_cdb(DATA)
+    rad = tmp_path / 'contact7.rad'
+    inter = [{
+        'type': 'TYPE7',
+        'name': 'cnt7',
+        'slave': [1, 2],
+        'master': [3, 4],
+        'fric': 0.2,
+    }]
+    write_rad(nodes, elements, str(rad), interfaces=inter)
+    txt = rad.read_text()
+    assert '/INTER/TYPE7/1' in txt
+    assert '/FRICTION' in txt
+


### PR DESCRIPTION
## Summary
- support `TYPE7` general contact
- document TYPE7 usage in README
- test TYPE7 interface creation

## Testing
- `pytest -q`
- `flake8` *(fails: E501 line too long)*
- `mypy cdb2rad`
- `bandit -r cdb2rad`

------
https://chatgpt.com/codex/tasks/task_e_685c5a163b9c8327957643fd95d5d703