### PR TITLE
Make CDB material inclusion optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ pestañas principales:
   ``model_0000.rad``.
 Se incluyen casillas opcionales para **sobrescribir** los archivos
 ``.inc`` o ``.rad`` si ya existen en el directorio de salida.
+- La opción **Incluir materiales del CDB** está desactivada por defecto;
+  actívala si deseas copiar al starter los materiales extraídos del `.cdb`.
 
 - **RAD limpio (.rad)** genera ``minimal.rad`` para probar rápidamente ``mesh.inc``.
 

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -459,7 +459,7 @@ if file_path:
             if st.session_state["init_vel"]:
                 st.json(st.session_state["init_vel"])
 
-        use_cdb_mats = st.checkbox("Incluir materiales del CDB", value=True)
+        use_cdb_mats = st.checkbox("Incluir materiales del CDB", value=False)
         use_impact = st.checkbox(
             "Incluir materiales de impacto", value=True
         )


### PR DESCRIPTION
## Summary
- dashboard: do not include CDB materials by default
- document the new behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c62496f6c8327a4040c27fec5af39