### PR TITLE
Reorder RAD writing to match example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ fichero mínimo contiene:
 /END
 ```
 
+El ``starter`` se organiza siguiendo un orden similar al de los ejemplos de
+OpenRadioss. Primero se colocan las tarjetas de control (``/RUN`` y
+parámetros de tiempo), seguidas de los materiales. A continuación se
+incluyen los nodos mediante ``#include`` y se definen las condiciones de
+contorno. Finalmente se añaden partes y propiedades antes de otras
+tarjetas opcionales como contactos o cargas iniciales.
+
 Cada bloque está descrito en detalle en la guía oficial de comandos de
 Radioss. Para depurar y ampliar estos ficheros se recomienda consultar el
 [Overview of the Input Reference Guide](https://help.altair.com/hwsolvers/rad/topics/solvers/rad/overview_ref_guide_rad_c.htm).

--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -77,12 +77,21 @@ def write_rad(
         f.write("     2024         0\n")
         f.write("                  kg                  mm                   s\n")
         f.write("                  kg                  mm                   s\n")
-        # radioss 2024 uses `#include` for file references
-        f.write(f"#include {mesh_inc}\n")
 
-        f.write(f"/PART/1/1/1\n")
-        f.write(f"/PROP/SHELL/1 {thickness} 0\n")
+        # 1. CONTROL CARDS
+        f.write(f"/RUN/{runname}/1/\n")
+        f.write(f"                {t_end}\n")
+        f.write("/STOP\n")
+        f.write("0 0 0 1 1 0\n")
+        f.write("/TFILE/0\n")
+        f.write(f"{tfile_dt}\n")
+        f.write("/VERS/2024\n")
+        f.write("/DT/NODA/CST/0\n")
+        f.write(f"{dt_ratio} 0 0\n")
+        f.write("/ANIM/DT\n")
+        f.write(f"0 {anim_dt}\n")
 
+        # 2. MATERIALS
         if not all_mats:
             f.write(f"/MAT/LAW1/1 {young} {poisson} {density}\n")
         else:
@@ -103,20 +112,10 @@ def write_rad(
                 else:
                     f.write(f"/MAT/LAW1/{mid} {e} {nu} {rho}\n")
 
+        # 3. NODES (from include file)
+        f.write(f"#include {mesh_inc}\n")
 
-        # Basic engine control cards
-        f.write(f"/RUN/{runname}/1/\n")
-        f.write(f"                {t_end}\n")
-        f.write("/STOP\n")
-        f.write("0 0 0 1 1 0\n")
-        f.write("/TFILE/0\n")
-        f.write(f"{tfile_dt}\n")
-        f.write("/VERS/2024\n")
-        f.write("/DT/NODA/CST/0\n")
-        f.write(f"{dt_ratio} 0 0\n")
-        f.write("/ANIM/DT\n")
-        f.write(f"0 {anim_dt}\n")
-
+        # 4. BOUNDARY CONDITIONS
         if boundary_conditions:
             for idx, bc in enumerate(boundary_conditions, start=1):
                 name = bc.get("name", f"BC_{idx}")
@@ -167,6 +166,10 @@ def write_rad(
                 f.write(f"{name}_master\n")
                 for nid in m_nodes:
                     f.write(f"{nid:10d}\n")
+
+        # 5. PARTS
+        f.write(f"/PART/1/1/1\n")
+        f.write(f"/PROP/SHELL/1 {thickness} 0\n")
 
         if init_velocity:
             nodes_v = init_velocity.get("nodes", [])


### PR DESCRIPTION
## Summary
- reorder sections in `writer_rad.py` to follow a consistent starter layout
- document card order in README

## Testing
- `flake8 || true`
- `mypy cdb2rad || true`
- `bandit -r cdb2rad || true`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c612eae548327aaf66bcdb534c703