### PR TITLE
Add 2022 Radioss reference guide links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ This repository implements a lightweight **translator between Ansys `.cdb` files
 
 The agent’s task is to help maintain and extend a Python program that takes as input a `.cdb` file exported from Ansys Mechanical or MAPDL, and produces:
 
+For all keyword formats and examples, consult the [Altair Radioss 2022 Reference Guide](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_ReferenceGuide.pdf), which is the primary source for this project.
+
 1. A **Radioss input mesh file** (`mesh.inc`) containing:
    - `/NODE`, `/SHELL`, `/BRICK` definitions
    - Formatted in **Radioss Block Input Syntax** (not Abaqus)
@@ -82,6 +84,7 @@ Codex must be able to:
   - Additional material laws: /MAT/LAW36, /MAT/PLAS_JOHNS, etc.
 
 ## 📍 Documentation links
+- [Altair Radioss 2022 Reference Guide](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_ReferenceGuide.pdf) — **primary reference** for block syntax.
 - Radioss Block Syntax Overview: <https://help.altair.com/hwsolvers/rad/topics/solvers/rad/block_format_overview_r.htm>
 - Radioss Input Syntax Reference: <https://help.altair.com/hwsolvers/rad/index.htm>
 - OpenRadioss GitHub: <https://github.com/OpenRadioss/OpenRadioss>

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ tarjetas opcionales como contactos o cargas iniciales.
 
 Cada bloque está descrito en detalle en la guía oficial de comandos de
 Radioss. Para depurar y ampliar estos ficheros se recomienda consultar el
+[Altair Radioss 2022 Reference Guide](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_ReferenceGuide.pdf) es la referencia principal para la sintaxis y
 [Overview of the Input Reference Guide](https://help.altair.com/hwsolvers/rad/topics/solvers/rad/overview_ref_guide_rad_c.htm).
 En ella se explica el formato, las palabras clave disponibles y la estructura
 del ``starter`` y los ficheros ``engine``.


### PR DESCRIPTION
## Summary
- cite the 2022 Radioss reference guide in AGENTS instructions
- mention the PDF guide as the main syntax reference in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c6de67bd8832785c4828819fff43a