### PR TITLE
Add Starlite mesh viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,14 @@ Tras pulsar *Generar .inc* o *Generar .rad* se muestran las primeras líneas de
 los ficheros generados.
 Cada pestaña permite elegir el directorio de salida y el nombre (sin extensión)
 del archivo para guardar fácilmente los resultados.
+
+## Vista 3D con Starlite
+
+Si prefieres una visualizaci\u00f3n ligera puedes usar un peque\u00f1o servidor basado en [Starlite](https://starliteproject.dev/).
+Ej\u00e9cutalo as\u00ed:
+
+```bash
+python scripts/starlite_viewer.py
+```
+
+Luego abre `http://localhost:8000/viewer?file=RUTA/AL/archivo.cdb` para rotar la malla con el rat\u00f3n.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 streamlit
+starlite
+uvicorn

--- a/scripts/starlite_viewer.py
+++ b/scripts/starlite_viewer.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import sys
+from starlite import Starlite, get
+from starlite.response import Response
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from cdb2rad.parser import parse_cdb
+from src.dashboard.app import viewer_html
+
+@get('/viewer')
+def viewer(file: str) -> Response:
+    nodes, elements, *_ = parse_cdb(file)
+    html = viewer_html(nodes, elements)
+    return Response(html, media_type='text/html')
+
+app = Starlite(route_handlers=[viewer])
+
+if __name__ == '__main__':
+    import uvicorn
+    uvicorn.run(app, host='0.0.0.0', port=8000)

--- a/tests/test_starlite_viewer.py
+++ b/tests/test_starlite_viewer.py
@@ -1,0 +1,16 @@
+import os
+import asyncio
+from httpx import AsyncClient, ASGITransport
+from scripts.starlite_viewer import app
+
+DATA = os.path.join(os.path.dirname(__file__), '..', 'data', 'model.cdb')
+
+def test_starlite_viewer_route():
+    async def _run():
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get('/viewer', params={'file': DATA})
+            assert resp.status_code == 200
+            assert 'OrbitControls' in resp.text
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add small Starlite server to preview meshes
- document how to run the viewer
- require starlite and uvicorn
- test the new route using httpx ASGI transport

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c6d2bed148327b8a1cf0ee0ca969b