### PR TITLE
Fix Three.js viewer and add set selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ Se puede subir un archivo ``.cdb`` propio. La interfaz cuenta con cuatro
 pestañas principales:
 
 - **Información** resumen de nodos y elementos.
-- **Vista 3D** previsualización ligera de la malla.
+- **Vista 3D** previsualización ligera de la malla con opción de seleccionar
+  los *name selections* que se quieran mostrar.
 
 -- **Generar INC** permite crear ``mesh.inc`` y muestra sus primeras líneas. \
   Incluye casillas para decidir si exportar las selecciones nombradas y los

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -12,3 +12,10 @@ def test_viewer_html_basic():
     assert 'LineSegments' in html
     assert 'MeshPhongMaterial' in html
     assert 'controls.target' in html
+
+
+def test_viewer_html_subset():
+    nodes, elements, *_ = parse_cdb(DATA)
+    subset = {e[0] for e in elements[:2]}
+    html = viewer_html(nodes, elements, selected_eids=subset)
+    assert 'OrbitControls' in html


### PR DESCRIPTION
## Summary
- fix link to `OrbitControls.js` in 3D preview
- allow filtering preview by element sets
- document the 3D viewer options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c6f78994c83279560f9d30645c9fe