### PR TITLE
Add prescribed motion BC option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ incluyen los nodos mediante ``#include`` y se definen las condiciones de
 contorno. Finalmente se añaden partes y propiedades antes de otras
 tarjetas opcionales como contactos o cargas iniciales.
 
+Las condiciones de contorno incluyen ahora la opción de **movimiento
+prescrito** (`/BOUNDARY/PRESCRIBED_MOTION`) además de las fijaciones
+tradicionales (`/BCS`). Estas se pueden seleccionar desde el dashboard y se
+exportan con la sintaxis correspondiente del Reference Guide.
+
 Cada bloque está descrito en detalle en la guía oficial de comandos de
 Radioss. Para depurar y ampliar estos ficheros se recomienda consultar el
 [Altair Radioss 2022 Reference Guide](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_ReferenceGuide.pdf) es la referencia principal para la sintaxis y

--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -144,15 +144,30 @@ def write_rad(
 
         if boundary_conditions:
             for idx, bc in enumerate(boundary_conditions, start=1):
+                bc_type = str(bc.get("type", "BCS")).upper()
                 name = bc.get("name", f"BC_{idx}")
-                tra = str(bc.get("tra", "000")).rjust(3, "0")
-                rot = str(bc.get("rot", "000")).rjust(3, "0")
                 nodes_bc = bc.get("nodes", [])
                 gid = 100 + idx
-                f.write(f"/BCS/{idx}\n")
-                f.write(f"{name}\n")
-                f.write("#  Tra rot   skew_ID  grnod_ID\n")
-                f.write(f"   {tra} {rot}         0        {gid}\n")
+
+                if bc_type == "BCS":
+                    tra = str(bc.get("tra", "000")).rjust(3, "0")
+                    rot = str(bc.get("rot", "000")).rjust(3, "0")
+                    f.write(f"/BCS/{idx}\n")
+                    f.write(f"{name}\n")
+                    f.write("#  Tra rot   skew_ID  grnod_ID\n")
+                    f.write(f"   {tra} {rot}         0        {gid}\n")
+                elif bc_type == "PRESCRIBED_MOTION":
+                    direction = int(bc.get("dir", 1))
+                    value = float(bc.get("value", 0.0))
+                    f.write(f"/BOUNDARY/PRESCRIBED_MOTION/{idx}\n")
+                    f.write(f"{name}\n")
+                    f.write("#   Dir    skew_ID   grnod_ID\n")
+                    f.write(f"    {direction}        0        {gid}\n")
+                    f.write(f"{value}\n")
+                else:
+                    f.write(f"# Unsupported BC type: {bc_type}\n")
+                    continue
+
                 f.write(f"/GRNOD/NODE/{gid}\n")
                 f.write(f"{name}_nodes\n")
                 for nid in nodes_bc:

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -402,23 +402,35 @@ if file_path:
 
         with st.expander("Condiciones de contorno (BCS)"):
             bc_name = st.text_input("Nombre BC", value="Fixed")
-            bc_tra = st.text_input("Traslación (111/000)", value="111")
-            bc_rot = st.text_input("Rotación (111/000)", value="111")
+            bc_type = st.selectbox(
+                "Tipo BC",
+                ["BCS", "PRESCRIBED_MOTION"],
+            )
             bc_set = st.selectbox(
                 "Conjunto de nodos",
                 list(node_sets.keys()),
                 disabled=not node_sets,
             )
+            bc_data = {}
+            if bc_type == "BCS":
+                bc_tra = st.text_input("Traslación (111/000)", value="111")
+                bc_rot = st.text_input("Rotación (111/000)", value="111")
+                bc_data.update({"tra": bc_tra, "rot": bc_rot})
+            else:
+                bc_dir = st.number_input("Dirección", value=1, step=1)
+                bc_val = st.number_input("Valor", value=0.0)
+                bc_data.update({"dir": int(bc_dir), "value": float(bc_val)})
+
             if st.button("Añadir BC") and bc_set:
                 node_list = node_sets.get(bc_set, [])
-                st.session_state["bcs"].append(
-                    {
-                        "name": bc_name,
-                        "tra": bc_tra,
-                        "rot": bc_rot,
-                        "nodes": node_list,
-                    }
-                )
+                entry = {
+                    "name": bc_name,
+                    "type": bc_type,
+                    "nodes": node_list,
+                }
+                entry.update(bc_data)
+                st.session_state["bcs"].append(entry)
+
             for bc in st.session_state["bcs"]:
                 st.json(bc)
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -142,6 +142,21 @@ def test_write_rad_with_bc(tmp_path):
     assert 'fixed' in txt
 
 
+def test_write_rad_with_prescribed(tmp_path):
+    nodes, elements, *_ = parse_cdb(DATA)
+    rad = tmp_path / 'prescribed.rad'
+    bc = [{
+        'name': 'move',
+        'type': 'PRESCRIBED_MOTION',
+        'dir': 1,
+        'value': 5.0,
+        'nodes': [1, 2]
+    }]
+    write_rad(nodes, elements, str(rad), boundary_conditions=bc)
+    txt = rad.read_text()
+    assert '/BOUNDARY/PRESCRIBED_MOTION/1' in txt
+
+
 def test_write_rad_with_impvel(tmp_path):
     nodes, elements, *_ = parse_cdb(DATA)
     rad = tmp_path / 'vel.rad'


### PR DESCRIPTION
## Summary
- support `/BOUNDARY/PRESCRIBED_MOTION` in writer
- allow choosing BC type in dashboard UI
- document prescribed motion in README
- test for prescribed motion BC

## Testing
- `flake8`
- `mypy cdb2rad src`
- `bandit -r cdb2rad src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c6fd86bd883278b0b4a35d6217d2c