### PR TITLE
Add dynamic interface types to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,14 @@ Se incluyen casillas opcionales para **sobrescribir** los archivos
 - **RAD limpio (.rad)** genera ``minimal.rad`` para probar rápidamente ``mesh.inc``.
 
 La pestaña *Generar RAD* también permite definir condiciones de contorno
-(tarjetas ``/BCS``), contactos simples (``/INTER/TYPE2``) o generales
-(``/INTER/TYPE7``), velocidades iniciales (``/IMPVEL``) y cargas de
-gravedad (``/GRAVITY``) seleccionando las *name selections* de nodos en un
-desplegable. Estos campos se pueden editar y añadir en el panel correspondiente
-antes de generar el archivo.
+(tarjetas ``/BCS``) y diferentes tipos de contactos mediante ``/INTER``.
+Se soportan tanto contactos simples ``TYPE2`` como contactos generales
+``TYPE7``. Al seleccionar el tipo de interacción en el panel se muestran los
+parámetros relevantes (por ejemplo ``gap``, ``stiff`` e ``igap`` para
+``TYPE7``). También se pueden asignar velocidades iniciales (``/IMPVEL``) y
+cargas de gravedad (``/GRAVITY``) seleccionando las *name selections* de nodos
+en un desplegable. Estos campos se pueden editar y añadir antes de generar el
+archivo.
 
 Tras pulsar *Generar .inc* o *Generar .rad* se muestran las primeras líneas de
 los ficheros generados.

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -423,7 +423,8 @@ if file_path:
                 st.json(bc)
 
         with st.expander("Interacciones (INTER)"):
-            int_name = st.text_input("Nombre interfaz", value="Tie")
+            int_type = st.selectbox("Tipo", ["TYPE2", "TYPE7"], key="itf_type")
+            int_name = st.text_input("Nombre interfaz", value=f"{int_type}_1")
             slave_set = st.selectbox(
                 "Conjunto esclavo",
                 list(node_sets.keys()),
@@ -437,17 +438,30 @@ if file_path:
                 disabled=not node_sets,
             )
             fric = st.number_input("Fricción", value=0.0)
+
+            gap = stiff = igap = None
+            if int_type == "TYPE7":
+                gap = st.number_input("Gap", value=0.0)
+                stiff = st.number_input("Stiffness", value=0.0)
+                igap = st.number_input("Igap", value=0, step=1)
+
             if st.button("Añadir interfaz") and slave_set and master_set:
                 s_list = node_sets.get(slave_set, [])
                 m_list = node_sets.get(master_set, [])
-                st.session_state["interfaces"].append(
-                    {
-                        "name": int_name,
-                        "slave": s_list,
-                        "master": m_list,
-                        "fric": fric,
-                    }
-                )
+                itf = {
+                    "type": int_type,
+                    "name": int_name,
+                    "slave": s_list,
+                    "master": m_list,
+                    "fric": fric,
+                }
+                if int_type == "TYPE7":
+                    itf.update({
+                        "gap": gap,
+                        "stiff": stiff,
+                        "igap": int(igap),
+                    })
+                st.session_state["interfaces"].append(itf)
             for itf in st.session_state["interfaces"]:
                 st.json(itf)
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -173,3 +173,19 @@ def test_write_rad_with_type7_contact(tmp_path):
     assert '/INTER/TYPE7/1' in txt
     assert '/FRICTION' in txt
 
+
+def test_write_rad_with_type2_contact(tmp_path):
+    nodes, elements, *_ = parse_cdb(DATA)
+    rad = tmp_path / 'contact2.rad'
+    inter = [{
+        'type': 'TYPE2',
+        'name': 'cnt2',
+        'slave': [1, 2],
+        'master': [3, 4],
+        'fric': 0.1,
+    }]
+    write_rad(nodes, elements, str(rad), interfaces=inter)
+    txt = rad.read_text()
+    assert '/INTER/TYPE2/1' in txt
+    assert '/FRICTION' in txt
+


### PR DESCRIPTION
## Summary
- add Streamlit UI controls for TYPE2 and TYPE7 interactions
- document interaction types in README
- add unit test for TYPE2 contact

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c7022fa008327b3316077f9ec259f