### PR TITLE
Add advanced engine controls

### DIFF
--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -41,6 +41,19 @@ def write_rad(
     anim_dt: float = DEFAULT_ANIM_DT,
     tfile_dt: float = DEFAULT_HISTORY_DT,
     dt_ratio: float = DEFAULT_DT_RATIO,
+    # Additional engine control options
+    print_n: int = -500,
+    print_line: int = 55,
+    rfile_cycle: int | None = None,
+    rfile_n: int | None = None,
+    h3d_dt: float | None = None,
+    stop_emax: float = 0.0,
+    stop_mmax: float = 0.0,
+    stop_nmax: float = 0.0,
+    stop_nth: int = 1,
+    stop_nanim: int = 1,
+    stop_nerr: int = 0,
+    adyrel: Tuple[float | None, float | None] | None = None,
     boundary_conditions: List[Dict[str, object]] | None = None,
     interfaces: List[Dict[str, object]] | None = None,
     init_velocity: Dict[str, object] | None = None,
@@ -79,10 +92,14 @@ def write_rad(
         f.write("                  kg                  mm                   s\n")
 
         f.write("/PART/1/1/1\n")
+        # General printout frequency
+        f.write(f"/PRINT/{print_n}/{print_line}\n")
         f.write(f"/RUN/{runname}/1/\n")
         f.write(f"                {t_end}\n")
         f.write("/STOP\n")
-        f.write("0 0 0 1 1 0\n")
+        f.write(
+            f"{stop_emax} {stop_mmax} {stop_nmax} {stop_nth} {stop_nanim} {stop_nerr}\n"
+        )
         f.write("/TFILE/0\n")
         f.write(f"{tfile_dt}\n")
         f.write("/VERS/2024\n")
@@ -90,6 +107,21 @@ def write_rad(
         f.write(f"{dt_ratio} 0 0\n")
         f.write("/ANIM/DT\n")
         f.write(f"0 {anim_dt}\n")
+        if h3d_dt is not None:
+            f.write("/H3D/DT\n")
+            f.write(f"0 {h3d_dt}\n")
+        if rfile_cycle is not None:
+            if rfile_n is not None:
+                f.write(f"/RFILE/{rfile_n}\n")
+            else:
+                f.write("/RFILE\n")
+            f.write(f"{rfile_cycle}\n")
+        if adyrel is not None:
+            f.write("/ADYREL\n")
+            if adyrel[0] is not None or adyrel[1] is not None:
+                tstart = 0.0 if adyrel[0] is None else adyrel[0]
+                tstop = t_end if adyrel[1] is None else adyrel[1]
+                f.write(f"{tstart} {tstop}\n")
 
         # 2. MATERIALS
         if not all_mats:

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -454,6 +454,28 @@ if file_path:
             dt_ratio = st.number_input(
                 "Factor seguridad DT", value=0.9, min_value=0.0, max_value=1.0
             )
+            st.markdown("### Opciones avanzadas")
+            print_n = st.number_input("PRINT cada n ciclos", value=-500, step=1)
+            print_line = st.number_input("Línea cabecera", value=55, step=1)
+            rfile_cycle = st.number_input("Ciclos entre RFILE", value=0, step=1)
+            rfile_n = st.number_input("Número de RFILE", value=0, step=1)
+            h3d_dt = st.number_input("Paso H3D", value=0.0, format="%.5f")
+            col1, col2, col3 = st.columns(3)
+            with col1:
+                stop_emax = st.number_input("Emax", value=0.0)
+            with col2:
+                stop_mmax = st.number_input("Mmax", value=0.0)
+            with col3:
+                stop_nmax = st.number_input("Nmax", value=0.0)
+            col4, col5, col6 = st.columns(3)
+            with col4:
+                stop_nth = st.number_input("NTH", value=1, step=1)
+            with col5:
+                stop_nanim = st.number_input("NANIM", value=1, step=1)
+            with col6:
+                stop_nerr = st.number_input("NERR_POSIT", value=0, step=1)
+            adyrel_start = st.number_input("ADYREL inicio", value=0.0)
+            adyrel_stop = st.number_input("ADYREL fin", value=0.0)
 
         with st.expander("Condiciones de contorno (BCS)"):
             bc_name = st.text_input("Nombre BC", value="Fixed")
@@ -613,6 +635,18 @@ if file_path:
                     anim_dt=anim_dt,
                     tfile_dt=tfile_dt,
                     dt_ratio=dt_ratio,
+                    print_n=int(print_n),
+                    print_line=int(print_line),
+                    rfile_cycle=int(rfile_cycle) if rfile_cycle else None,
+                    rfile_n=int(rfile_n) if rfile_n else None,
+                    h3d_dt=h3d_dt if h3d_dt > 0 else None,
+                    stop_emax=stop_emax,
+                    stop_mmax=stop_mmax,
+                    stop_nmax=stop_nmax,
+                    stop_nth=int(stop_nth),
+                    stop_nanim=int(stop_nanim),
+                    stop_nerr=int(stop_nerr),
+                    adyrel=(adyrel_start, adyrel_stop),
 
                     boundary_conditions=st.session_state.get("bcs"),
                     interfaces=st.session_state.get("interfaces"),


### PR DESCRIPTION
## Summary
- extend writer_rad with additional Radioss engine controls (`/PRINT`, `/RFILE`, `/H3D/DT`, `/ADYREL`, `/STOP` parameters)
- expose new controls in the dashboard under *Control del cálculo*
- update tests (they still pass)

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c73f2dbe08327b71ea7d94ccb826a