### PR TITLE
Add PDF help search

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,3 +159,7 @@ Tras pulsar *Generar .inc* o *Generar .rad* se muestran las primeras líneas de
 los ficheros generados.
 Cada pestaña permite elegir el directorio de salida y el nombre (sin extensión)
 del archivo para guardar fácilmente los resultados.
+
+### Ayuda interactiva
+
+La pestaña **Ayuda** permite buscar texto en la [Reference Guide](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_ReferenceGuide.pdf) y el [Theory Manual](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_TheoryManual.pdf). Introduce una palabra clave y se muestran las primeras coincidencias encontradas. También se incluye un enlace directo para abrir el documento completo.

--- a/cdb2rad/pdf_search.py
+++ b/cdb2rad/pdf_search.py
@@ -1,0 +1,44 @@
+import io
+from functools import lru_cache
+from typing import List
+
+import requests
+from PyPDF2 import PdfReader
+
+REFERENCE_GUIDE = (
+    "https://2022.help.altair.com/2022/simulation/pdfs/radopen/"
+    "AltairRadioss_2022_ReferenceGuide.pdf"
+)
+THEORY_MANUAL = (
+    "https://2022.help.altair.com/2022/simulation/pdfs/radopen/"
+    "AltairRadioss_2022_TheoryManual.pdf"
+)
+
+
+@lru_cache(maxsize=2)
+def _fetch_pdf(url: str) -> str:
+    """Download and extract text from the given PDF URL."""
+    resp = requests.get(url)
+    resp.raise_for_status()
+    reader = PdfReader(io.BytesIO(resp.content))
+    text_parts = []
+    for page in reader.pages:
+        t = page.extract_text()
+        if t:
+            text_parts.append(t)
+    return "\n".join(text_parts)
+
+
+def search_pdf(url: str, query: str, max_hits: int = 5) -> List[str]:
+    """Return up to ``max_hits`` lines containing the query from the PDF."""
+    content = _fetch_pdf(url)
+    results: List[str] = []
+    q = query.lower()
+    for line in content.splitlines():
+        if q in line.lower():
+            line = line.strip()
+            if line:
+                results.append(line)
+            if len(results) >= max_hits:
+                break
+    return results

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 streamlit
+PyPDF2

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -23,6 +23,11 @@ if root_path not in sys.path:
 from cdb2rad.parser import parse_cdb
 from cdb2rad.writer_rad import write_rad
 from cdb2rad.writer_inc import write_mesh_inc
+from cdb2rad.pdf_search import (
+    REFERENCE_GUIDE,
+    THEORY_MANUAL,
+    search_pdf,
+)
 
 
 MAX_EDGES = 10000
@@ -295,11 +300,12 @@ if file_path:
     )
     st.session_state["work_dir"] = work_dir
     nodes, elements, node_sets, elem_sets, materials = load_cdb(file_path)
-    info_tab, preview_tab, inp_tab, rad_tab = st.tabs([
+    info_tab, preview_tab, inp_tab, rad_tab, help_tab = st.tabs([
         "Información",
         "Vista 3D",
         "Generar INC",
         "Generar RAD",
+        "Ayuda",
     ])
 
     with info_tab:
@@ -721,5 +727,20 @@ if file_path:
                 st.success("Archivo RAD limpio generado")
                 lines = rad_path.read_text().splitlines()[:20]
                 st.code("\n".join(lines))
+
+    with help_tab:
+        st.subheader("Buscar en documentación")
+        doc_choice = st.selectbox("Documento", ["Reference Guide", "Theory Manual"])
+        query = st.text_input("Término de búsqueda")
+        if st.button("Buscar", key="search_docs") and query:
+            url = REFERENCE_GUIDE if doc_choice == "Reference Guide" else THEORY_MANUAL
+            results = search_pdf(url, query)
+            if results:
+                for r in results:
+                    st.write(r)
+            else:
+                st.warning("Sin coincidencias")
+        link = REFERENCE_GUIDE if doc_choice == "Reference Guide" else THEORY_MANUAL
+        st.markdown(f"[Abrir {doc_choice}]({link})")
 else:
     st.info("Sube un archivo .cdb")


### PR DESCRIPTION
## Summary
- add `pdf_search.py` with simple PDF downloader and text search
- integrate reference PDF search in dashboard under new *Ayuda* tab
- document help feature in README
- require PyPDF2 in dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c7905e81883279ff3082a4907db05