### PR TITLE
Fix dashboard crash on missing PyPDF2

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,3 +172,5 @@ del archivo para guardar fácilmente los resultados.
 ### Ayuda interactiva
 
 La pestaña **Ayuda** permite buscar texto en la [Reference Guide](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_ReferenceGuide.pdf) y el [Theory Manual](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_TheoryManual.pdf). Introduce una palabra clave y se muestran las primeras coincidencias encontradas. También se incluye un enlace directo para abrir el documento completo.
+
+> **Nota**: la búsqueda en PDF requiere la librería `PyPDF2`. Si no está instalada, la pestaña seguirá funcionando, pero la búsqueda mostrará un mensaje de aviso.

--- a/cdb2rad/pdf_search.py
+++ b/cdb2rad/pdf_search.py
@@ -3,7 +3,11 @@ from functools import lru_cache
 from typing import List
 
 import requests
-from PyPDF2 import PdfReader
+
+try:  # PyPDF2 is optional
+    from PyPDF2 import PdfReader  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - handled in search_pdf
+    PdfReader = None
 
 REFERENCE_GUIDE = (
     "https://2022.help.altair.com/2022/simulation/pdfs/radopen/"
@@ -18,8 +22,12 @@ THEORY_MANUAL = (
 @lru_cache(maxsize=2)
 def _fetch_pdf(url: str) -> str:
     """Download and extract text from the given PDF URL."""
+    if PdfReader is None:
+        raise ImportError("PyPDF2 is required for PDF search")
+
     resp = requests.get(url)
     resp.raise_for_status()
+
     reader = PdfReader(io.BytesIO(resp.content))
     text_parts = []
     for page in reader.pages:

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -796,12 +796,22 @@ if file_path:
         query = st.text_input("Término de búsqueda")
         if st.button("Buscar", key="search_docs") and query:
             url = REFERENCE_GUIDE if doc_choice == "Reference Guide" else THEORY_MANUAL
-            results = search_pdf(url, query)
-            if results:
-                for r in results:
-                    st.write(r)
-            else:
-                st.warning("Sin coincidencias")
+            results = None
+            try:
+                results = search_pdf(url, query)
+            except ImportError:
+                st.error(
+                    "PyPDF2 no está instalado. Instala la dependencia para habilitar la búsqueda."
+                )
+            except Exception as e:  # pragma: no cover - network errors
+                st.error(f"No se pudo buscar en el PDF: {e}")
+
+            if results is not None:
+                if results:
+                    for r in results:
+                        st.write(r)
+                else:
+                    st.warning("Sin coincidencias")
         link = REFERENCE_GUIDE if doc_choice == "Reference Guide" else THEORY_MANUAL
         st.markdown(f"[Abrir {doc_choice}]({link})")
 else:


### PR DESCRIPTION
## Summary
- handle optional PyPDF2 import in `pdf_search`
- show a helpful message in the dashboard when the dependency is missing
- document the optional dependency in README
- avoid spurious "Sin coincidencias" warning when the search fails

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c7f4133a083279f1cf737a65c0e9c