### PR TITLE
Add offline PDF search feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ openradioss_bin/
 *.zip
 mesh.inc
 sample.rad
+docs/*.pdf

--- a/README.md
+++ b/README.md
@@ -171,6 +171,6 @@ del archivo para guardar fácilmente los resultados.
 
 ### Ayuda interactiva
 
-La pestaña **Ayuda** permite buscar texto en la [Reference Guide](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_ReferenceGuide.pdf) y el [Theory Manual](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_TheoryManual.pdf). Introduce una palabra clave y se muestran las primeras coincidencias encontradas. También se incluye un enlace directo para abrir el documento completo.
+La pestaña **Ayuda** permite buscar texto en la [Reference Guide](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_ReferenceGuide.pdf) y el [Theory Manual](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_TheoryManual.pdf). Si copias estos PDF en la carpeta ``docs/`` (o los descargas con ``scripts/download_docs.py``), la búsqueda se realiza de forma local. Introduce una palabra clave y se muestran las primeras coincidencias encontradas. También se incluye un enlace directo para abrir el documento completo.
 
 > **Nota**: la búsqueda en PDF requiere la librería `PyPDF2`. Si no está instalada, la pestaña seguirá funcionando, pero la búsqueda mostrará un mensaje de aviso.

--- a/cdb2rad/pdf_search.py
+++ b/cdb2rad/pdf_search.py
@@ -1,6 +1,7 @@
 import io
 from functools import lru_cache
 from typing import List
+from pathlib import Path
 
 import requests
 
@@ -9,26 +10,35 @@ try:  # PyPDF2 is optional
 except ModuleNotFoundError:  # pragma: no cover - handled in search_pdf
     PdfReader = None
 
-REFERENCE_GUIDE = (
+REFERENCE_GUIDE_URL = (
     "https://2022.help.altair.com/2022/simulation/pdfs/radopen/"
     "AltairRadioss_2022_ReferenceGuide.pdf"
 )
-THEORY_MANUAL = (
+THEORY_MANUAL_URL = (
     "https://2022.help.altair.com/2022/simulation/pdfs/radopen/"
     "AltairRadioss_2022_TheoryManual.pdf"
 )
 
+DOCS_DIR = Path(__file__).resolve().parents[1] / "docs"
+REFERENCE_GUIDE = DOCS_DIR / "AltairRadioss_2022_ReferenceGuide.pdf"
+THEORY_MANUAL = DOCS_DIR / "AltairRadioss_2022_TheoryManual.pdf"
+
 
 @lru_cache(maxsize=2)
-def _fetch_pdf(url: str) -> str:
-    """Download and extract text from the given PDF URL."""
+def _fetch_pdf(source: str | Path) -> str:
+    """Return the text content of ``source`` which can be a URL or file."""
     if PdfReader is None:
         raise ImportError("PyPDF2 is required for PDF search")
 
-    resp = requests.get(url)
-    resp.raise_for_status()
+    if isinstance(source, (str, Path)) and Path(str(source)).exists():
+        with open(source, "rb") as fh:
+            data = fh.read()
+    else:
+        resp = requests.get(str(source))
+        resp.raise_for_status()
+        data = resp.content
 
-    reader = PdfReader(io.BytesIO(resp.content))
+    reader = PdfReader(io.BytesIO(data))
     text_parts = []
     for page in reader.pages:
         t = page.extract_text()
@@ -37,9 +47,9 @@ def _fetch_pdf(url: str) -> str:
     return "\n".join(text_parts)
 
 
-def search_pdf(url: str, query: str, max_hits: int = 5) -> List[str]:
-    """Return up to ``max_hits`` lines containing the query from the PDF."""
-    content = _fetch_pdf(url)
+def search_pdf(source: str | Path, query: str, max_hits: int = 5) -> List[str]:
+    """Return up to ``max_hits`` lines containing ``query`` in the PDF."""
+    content = _fetch_pdf(source)
     results: List[str] = []
     q = query.lower()
     for line in content.splitlines():

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+# Documentation
+
+Place the Altair Radioss PDF guides here to enable offline search in the dashboard.
+
+Required filenames:
+
+- `AltairRadioss_2022_ReferenceGuide.pdf`
+- `AltairRadioss_2022_TheoryManual.pdf`
+
+You can download them automatically with:
+
+```bash
+python scripts/download_docs.py --dir docs
+```

--- a/scripts/download_docs.py
+++ b/scripts/download_docs.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+"""Download Altair Radioss documentation PDFs for offline use."""
+
+import argparse
+from pathlib import Path
+import requests
+
+REFERENCE_GUIDE_URL = (
+    "https://2022.help.altair.com/2022/simulation/pdfs/radopen/"
+    "AltairRadioss_2022_ReferenceGuide.pdf"
+)
+THEORY_MANUAL_URL = (
+    "https://2022.help.altair.com/2022/simulation/pdfs/radopen/"
+    "AltairRadioss_2022_TheoryManual.pdf"
+)
+
+PDFS = {
+    REFERENCE_GUIDE_URL: "AltairRadioss_2022_ReferenceGuide.pdf",
+    THEORY_MANUAL_URL: "AltairRadioss_2022_TheoryManual.pdf",
+}
+
+
+def download(url: str, dest: Path) -> None:
+    if dest.exists():
+        print(f"{dest} already exists")
+        return
+    resp = requests.get(url, stream=True)
+    resp.raise_for_status()
+    with open(dest, "wb") as fh:
+        for chunk in resp.iter_content(chunk_size=8192):
+            fh.write(chunk)
+    print(f"Downloaded {dest}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dir", default="docs", help="Destination directory")
+    args = parser.parse_args()
+    out_dir = Path(args.dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for url, name in PDFS.items():
+        download(url, out_dir / name)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -792,12 +792,27 @@ if file_path:
 
     with help_tab:
         st.subheader("Buscar en documentación")
-        doc_choice = st.selectbox("Documento", ["Reference Guide", "Theory Manual"])
+        doc_choice = st.selectbox(
+            "Documento", ["Reference Guide", "Theory Manual"]
+        )
         query = st.text_input("Término de búsqueda")
         if st.button("Buscar", key="search_docs") and query:
-            url = REFERENCE_GUIDE if doc_choice == "Reference Guide" else THEORY_MANUAL
+            if doc_choice == "Reference Guide":
+                source = (
+                    REFERENCE_GUIDE
+                    if REFERENCE_GUIDE.exists()
+                    else REFERENCE_GUIDE_URL
+                )
+                link = REFERENCE_GUIDE_URL
+            else:
+                source = (
+                    THEORY_MANUAL
+                    if THEORY_MANUAL.exists()
+                    else THEORY_MANUAL_URL
+                )
+                link = THEORY_MANUAL_URL
             try:
-                results = search_pdf(url, query)
+                results = search_pdf(source, query)
             except ImportError:
                 st.error("PyPDF2 no está instalado. Instala la dependencia para habilitar la búsqueda.")
                 results = []
@@ -809,7 +824,10 @@ if file_path:
                     st.write(r)
             elif results == []:
                 st.warning("Sin coincidencias")
-        link = REFERENCE_GUIDE if doc_choice == "Reference Guide" else THEORY_MANUAL
+        else:
+            link = (
+                REFERENCE_GUIDE_URL if doc_choice == "Reference Guide" else THEORY_MANUAL_URL
+            )
         st.markdown(f"[Abrir {doc_choice}]({link})")
 else:
     st.info("Sube un archivo .cdb")


### PR DESCRIPTION
## Summary
- enable pdf_search to read local files
- add scripts/download_docs.py to fetch docs
- update dashboard to prefer local PDFs
- document offline search in README
- ignore docs/*.pdf in git

## Testing
- `flake8 .` *(fails: E501 line too long)*
- `mypy .` *(fails: missing requests stubs)*
- `bandit -r .` *(warns about requests without timeout)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c81ee9f3c8327a4726d4abd55770a