### PR TITLE
Enhance material section

### DIFF
--- a/tests/test_material_section.py
+++ b/tests/test_material_section.py
@@ -1,0 +1,37 @@
+import os
+from cdb2rad.parser import parse_cdb
+from cdb2rad.writer_rad import write_rad
+
+DATA = os.path.join(os.path.dirname(__file__), '..', 'data', 'model.cdb')
+
+
+def test_material_blocks(tmp_path):
+    nodes, elements, node_sets, elem_sets, mats = parse_cdb(DATA)
+    extra = {
+        20: {
+            'LAW': 'LAW36',
+            'NAME': 'DP600',
+            'CURVE': [(0.0, 300.0), (0.1, 400.0)],
+        }
+    }
+    rad = tmp_path / 'mat.rad'
+    write_rad(
+        nodes,
+        elements,
+        str(rad),
+        node_sets=node_sets,
+        elem_sets=elem_sets,
+        materials=mats,
+        extra_materials=extra,
+    )
+    lines = rad.read_text().splitlines()
+    mat_count = sum(1 for l in lines if l.startswith('/MAT/'))
+    assert mat_count == len(mats) + len(extra)
+    idxs = [i for i, l in enumerate(lines) if l.startswith('/MAT/')]
+    for idx in idxs:
+        assert len(lines) > idx + 2
+    if any('/MAT/LAW36/' in lines[i] for i in idxs):
+        idx = next(i for i, l in enumerate(lines) if l.startswith('/MAT/LAW36/'))
+        fct_line = next(l for l in lines[idx:] if l.startswith('# fct_IDp'))
+        fct_id = int(lines[lines.index(fct_line) + 1].split()[0])
+        assert any(line.startswith(f'/FUNCT/{fct_id}') for line in lines)


### PR DESCRIPTION
## Summary
- expand material generation in `writer_rad` for multiple laws
- include optional /FUNCT curves and BIQUAD failure cards
- add regression test for material blocks

## Testing
- `flake8` *(fails: E501 etc.)*
- `mypy cdb2rad` *(fails: several typing errors)*
- `bandit -r cdb2rad`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c85f082b883279a4122967451b230