### PR TITLE
Add function definitions and integration in dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ Se incluyen casillas opcionales para **sobrescribir** los archivos
 
 - **RAD limpio (.rad)** genera ``minimal.rad`` para probar rápidamente ``mesh.inc``.
 
+La sección *Funciones (FUNCT)* permite definir tablas ``X,Y`` y asignarlas a
+movimientos prescritos. En el desplegable de valor se puede escoger un ID de
+función además de introducir un número.
+
 La pestaña *Generar RAD* también permite definir condiciones de contorno
 
 (tarjetas ``/BCS``), contactos simples (``/INTER/TYPE2``) o generales

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -158,6 +158,24 @@ def test_write_rad_with_prescribed(tmp_path):
     assert '/BOUNDARY/PRESCRIBED_MOTION/1' in txt
 
 
+def test_write_rad_with_function(tmp_path):
+    nodes, elements, *_ = parse_cdb(DATA)
+    rad = tmp_path / 'func.rad'
+    bc = [{
+        'name': 'move_fun',
+        'type': 'PRESCRIBED_MOTION',
+        'dir': 1,
+        'value': 5.0,
+        'function': 10,
+        'nodes': [1, 2]
+    }]
+    funcs = {10: {'name': 'ramp', 'points': [(0.0, 0.0), (0.01, 5.0)]}}
+    write_rad(nodes, elements, str(rad), boundary_conditions=bc, functions=funcs)
+    txt = rad.read_text()
+    assert '/FUNCT/10' in txt
+    assert '/BOUNDARY/PRESCRIBED_MOTION/1' in txt
+
+
 def test_write_rad_with_impvel(tmp_path):
     nodes, elements, *_ = parse_cdb(DATA)
     rad = tmp_path / 'vel.rad'

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -38,6 +38,22 @@ def test_generated_rad_format(tmp_path):
     validate_rad_format(str(rad))
 
 
+def test_validate_with_function(tmp_path):
+    nodes, elements, *_ = parse_cdb(DATA)
+    rad = tmp_path / 'func.rad'
+    bc = [{
+        'name': 'move',
+        'type': 'PRESCRIBED_MOTION',
+        'dir': 1,
+        'value': 5.0,
+        'function': 2,
+        'nodes': [1]
+    }]
+    funcs = {2: {'name': 'ramp', 'points': [(0.0, 0.0), (0.02, 5.0)]}}
+    write_rad(nodes, elements, str(rad), boundary_conditions=bc, functions=funcs)
+    validate_rad_format(str(rad))
+
+
 def test_invalid_keyword(tmp_path):
     bad = tmp_path / "bad.rad"
     bad.write_text("/UNKNOWN\n1 2 3\n")


### PR DESCRIPTION
## Summary
- allow definition of FUNCT blocks in `write_rad`
- support attaching function IDs to prescribed motions
- add Streamlit widgets to create functions and select them when defining BCs
- document new functionality in README
- test FUNCT generation and validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c87f10eb08327994435f4bb3eeb93