### PR TITLE
Add optional mesh include in RAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ del ``starter`` y los ficheros ``engine``.
 python scripts/run_all.py data_files/model.cdb --inc mesh.inc --rad model_0000.rad
 ```
 
+Por defecto, ``model_0000.rad`` incluye la línea ``#include mesh.inc``. Con la
+opción ``--skip-include`` se genera el ``.rad`` sin esa referencia:
+
+```bash
+python scripts/run_all.py data_files/model.cdb --rad model.rad --skip-include
+```
+
 ### Entorno virtual y OpenRadioss
 
 Para crear un entorno virtual con `pytest` y descargar la última

--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -39,6 +39,7 @@ def write_rad(
     elements: List[Tuple[int, int, List[int]]],
     outfile: str,
     mesh_inc: str = "mesh.inc",
+    include_inc: bool = True,
     node_sets: Dict[str, List[int]] | None = None,
     elem_sets: Dict[str, List[int]] | None = None,
     materials: Dict[int, Dict[str, float]] | None = None,
@@ -78,7 +79,8 @@ def write_rad(
     Parameters allow customizing material properties and basic engine
     settings such as final time, animation frequency and time-step
     controls. Gravity loading can be specified via the ``gravity``
-    parameter.
+    parameter. Set ``include_inc`` to ``False`` to omit the
+    ``#include`` line referencing the mesh.
     """
 
     all_mats: Dict[int, Dict[str, float]] = {}
@@ -89,14 +91,15 @@ def write_rad(
     if all_mats:
         all_mats = apply_default_materials(all_mats)
 
-    write_mesh_inc(
-        nodes,
-        elements,
-        mesh_inc,
-        node_sets=node_sets,
-        elem_sets=elem_sets,
-        materials=all_mats if all_mats else None,
-    )
+    if include_inc:
+        write_mesh_inc(
+            nodes,
+            elements,
+            mesh_inc,
+            node_sets=node_sets,
+            elem_sets=elem_sets,
+            materials=all_mats if all_mats else None,
+        )
 
     with open(outfile, "w") as f:
         f.write("#RADIOSS STARTER\n")
@@ -276,7 +279,8 @@ def write_rad(
                             f.write(" ".join(vals) + "\n")
 
         # 3. NODES (from include file)
-        f.write(f"#include {mesh_inc}\n")
+        if include_inc:
+            f.write(f"#include {mesh_inc}\n")
 
 
         # Basic engine control cards
@@ -395,8 +399,13 @@ def write_minimal_rad(
     outfile: str,
     mesh_inc: str = "mesh.inc",
     runname: str = DEFAULT_RUNNAME,
+    *,
+    include_inc: bool = True,
 ) -> None:
-    """Generate a minimal starter file referencing only the mesh."""
+    """Generate a minimal starter file referencing only the mesh.
+
+    Set ``include_inc`` to ``False`` to omit the ``#include`` line.
+    """
 
     with open(outfile, "w") as f:
         f.write("#RADIOSS STARTER\n")
@@ -405,5 +414,6 @@ def write_minimal_rad(
         f.write("     2024         0\n")
         f.write("                  kg                  mm                   s\n")
         f.write("                  kg                  mm                   s\n")
-        f.write(f"#include {mesh_inc}\n")
+        if include_inc:
+            f.write(f"#include {mesh_inc}\n")
         f.write("/END\n")

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -20,6 +20,11 @@ def main() -> None:
     parser.add_argument("--rad", dest="rad", help="Output .rad file")
     parser.add_argument("--inc", dest="inc", help="Output mesh.inc file")
     parser.add_argument("--exec", dest="exec_path", help="Run OpenRadioss starter after generation")
+    parser.add_argument(
+        "--skip-include",
+        action="store_true",
+        help="Do not include the mesh.inc file inside the generated .rad",
+    )
 
     args = parser.parse_args()
 
@@ -45,6 +50,7 @@ def main() -> None:
             elements,
             args.rad,
             mesh_inc=args.inc or "mesh.inc",
+            include_inc=not args.skip_include,
             node_sets=node_sets,
             elem_sets=elem_sets,
             materials=materials,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -236,3 +236,11 @@ def test_write_rad_advanced_options(tmp_path):
     assert '/ADYREL' in text
 
 
+def test_write_rad_without_include(tmp_path):
+    nodes, elements, *_ = parse_cdb(DATA)
+    rad = tmp_path / 'noinc.rad'
+    write_rad(nodes, elements, str(rad), include_inc=False)
+    content = rad.read_text()
+    assert '#include' not in content
+
+


### PR DESCRIPTION
## Summary
- allow disabling `#include mesh.inc` with a new parameter `include_inc` in `write_rad` and `write_minimal_rad`
- support `--skip-include` flag in `run_all.py`
- document new option in README
- test generating `.rad` without including mesh

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c896f5658832790aaae5e985b8404