### PR TITLE
FIX: generate clean RAD when dashboard has no options

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -747,7 +747,10 @@ if file_path:
             rad_path = out_dir / f"{rad_name}.rad"
             mesh_path = out_dir / "mesh.inc"
             no_opts = (
-                not use_cdb_mats and not use_impact
+                not use_cdb_mats
+                and not (
+                    use_impact and st.session_state.get("impact_materials")
+                )
                 and not st.session_state.get("bcs")
                 and not st.session_state.get("interfaces")
                 and not st.session_state.get("init_vel")


### PR DESCRIPTION
## Summary
- handle checkbox states to generate minimal RAD when no options are chosen

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c8da60e3c8327b91baf7785661943