### PR TITLE
Add units selector to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ streamlit run src/dashboard/app.py
 Se puede subir un archivo ``.cdb`` propio. La interfaz cuenta con cuatro
 pestañas principales:
 
+- En la parte superior se puede elegir el **sistema de unidades** (``SI`` o
+  ``Imperial``). Las casillas de entrada mostrarán automáticamente la unidad
+  correspondiente en cada parámetro.
+
 - **Información** resumen de nodos y elementos.
 - **Vista 3D** previsualización ligera de la malla con opción de seleccionar
   los *name selections* que se quieran mostrar.


### PR DESCRIPTION
## Summary
- let the dashboard choose SI or Imperial units
- label all relevant numeric inputs with the units of the chosen system
- document the new selector in the README

## Testing
- `flake8 src/dashboard/app.py`
- `mypy src/dashboard/app.py`
- `bandit -r src/dashboard/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c8f32ebb48327a869d18491221d2a