### PR TITLE
Remove duplicated engine control block

### DIFF
--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -283,19 +283,6 @@ def write_rad(
             f.write(f"#include {mesh_inc}\n")
 
 
-        # Basic engine control cards
-        f.write("/STOP\n")
-        f.write(f"{t_end}\n")
-        f.write("0 0 0 1 1 0\n")
-        f.write("/TFILE/0\n")
-        f.write(f"{tfile_dt}\n")
-        f.write("/VERS/2024\n")
-        f.write("/DT/NODA/CST/0\n")
-        f.write(f"{dt_ratio} 0 0\n")
-        f.write("/ANIM/DT\n")
-        f.write(f"0 {anim_dt}\n")
-
-
         # 4. BOUNDARY CONDITIONS
 
         if boundary_conditions:


### PR DESCRIPTION
## Summary
- avoid emitting duplicate engine control cards in model_0000.rad

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d0417b68c8327ac58e66cdf06394f