### PR TITLE
Fix dashboard docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ del archivo para guardar fácilmente los resultados.
 
 ### Ayuda interactiva
 
-La pestaña **Ayuda** permite buscar texto en la [Reference Guide](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_ReferenceGuide.pdf) y el [Theory Manual](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_TheoryManual.pdf). Introduce una palabra clave y se muestran las primeras coincidencias encontradas. También se incluye un enlace directo para abrir el documento completo.
+La pestaña **Ayuda** contiene enlaces directos a la documentación oficial de Altair Radioss:
 
-> **Nota**: la búsqueda en PDF requiere la librería `PyPDF2`. Si no está instalada, la pestaña seguirá funcionando, pero la búsqueda mostrará un mensaje de aviso.
+- [Reference Guide](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_ReferenceGuide.pdf)
+- [Theory Manual](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_TheoryManual.pdf)
+- [User Guide](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_UserGuide.pdf)
+
+Si copias estos PDF en la carpeta ``docs/`` (o los descargas con ``scripts/download_docs.py``) podrás consultarlos sin conexión.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,15 @@
+# Documentation
+
+Place the Altair Radioss PDF guides here for offline reference.
+
+Required filenames:
+
+- `AltairRadioss_2022_ReferenceGuide.pdf`
+- `AltairRadioss_2022_TheoryManual.pdf`
+- `AltairRadioss_2022_UserGuide.pdf`
+
+You can download them automatically with:
+
+```bash
+python scripts/download_docs.py --dir docs
+```

--- a/scripts/download_docs.py
+++ b/scripts/download_docs.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+"""Download Altair Radioss documentation PDFs for offline use."""
+
+import argparse
+from pathlib import Path
+import requests
+
+REFERENCE_GUIDE_URL = (
+    "https://2022.help.altair.com/2022/simulation/pdfs/radopen/"
+    "AltairRadioss_2022_ReferenceGuide.pdf"
+)
+THEORY_MANUAL_URL = (
+    "https://2022.help.altair.com/2022/simulation/pdfs/radopen/"
+    "AltairRadioss_2022_TheoryManual.pdf"
+)
+USER_GUIDE_URL = (
+    "https://2022.help.altair.com/2022/simulation/pdfs/radopen/"
+    "AltairRadioss_2022_UserGuide.pdf"
+)
+
+PDFS = {
+    REFERENCE_GUIDE_URL: "AltairRadioss_2022_ReferenceGuide.pdf",
+    THEORY_MANUAL_URL: "AltairRadioss_2022_TheoryManual.pdf",
+    USER_GUIDE_URL: "AltairRadioss_2022_UserGuide.pdf",
+}
+
+
+def download(url: str, dest: Path) -> None:
+    if dest.exists():
+        print(f"{dest} already exists")
+        return
+    resp = requests.get(url, stream=True)
+    resp.raise_for_status()
+    with open(dest, "wb") as fh:
+        for chunk in resp.iter_content(chunk_size=8192):
+            fh.write(chunk)
+    print(f"Downloaded {dest}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dir", default="docs", help="Destination directory")
+    args = parser.parse_args()
+    out_dir = Path(args.dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for url, name in PDFS.items():
+        download(url, out_dir / name)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -39,9 +39,9 @@ from cdb2rad.writer_rad import (
 )
 from cdb2rad.writer_inc import write_mesh_inc
 from cdb2rad.pdf_search import (
-    REFERENCE_GUIDE,
-    THEORY_MANUAL,
-    search_pdf,
+    REFERENCE_GUIDE_URL,
+    THEORY_MANUAL_URL,
+    USER_GUIDE_URL,
 )
 
 
@@ -791,25 +791,12 @@ if file_path:
                 st.code("\n".join(lines))
 
     with help_tab:
-        st.subheader("Buscar en documentación")
-        doc_choice = st.selectbox("Documento", ["Reference Guide", "Theory Manual"])
-        query = st.text_input("Término de búsqueda")
-        if st.button("Buscar", key="search_docs") and query:
-            url = REFERENCE_GUIDE if doc_choice == "Reference Guide" else THEORY_MANUAL
-            try:
-                results = search_pdf(url, query)
-            except ImportError:
-                st.error("PyPDF2 no está instalado. Instala la dependencia para habilitar la búsqueda.")
-                results = []
-            except Exception as e:  # pragma: no cover - network errors
-                st.error(f"No se pudo buscar en el PDF: {e}")
-                results = []
-            if results:
-                for r in results:
-                    st.write(r)
-            elif results == []:
-                st.warning("Sin coincidencias")
-        link = REFERENCE_GUIDE if doc_choice == "Reference Guide" else THEORY_MANUAL
-        st.markdown(f"[Abrir {doc_choice}]({link})")
+        st.subheader("Documentación")
+        st.markdown(
+            "- [Reference Guide](%s)\n"
+            "- [Theory Manual](%s)\n"
+            "- [User Guide](%s)"
+            % (REFERENCE_GUIDE_URL, THEORY_MANUAL_URL, USER_GUIDE_URL)
+        )
 else:
     st.info("Sube un archivo .cdb")


### PR DESCRIPTION
## Summary
- remove PDF search widget from help tab
- link to offline docs: Reference Guide, Theory Manual and User Guide
- document docs download script

## Testing
- `flake8 .` *(fails: various style issues)*
- `mypy .` *(fails: missing stubs for requests and streamlit)*
- `bandit -r .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c81ee9f3c8327a4726d4abd55770a