### PR TITLE
FIX: update help docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,4 @@ del archivo para guardar fácilmente los resultados.
 
 ### Ayuda interactiva
 
-La pestaña **Ayuda** permite buscar texto en la [Reference Guide](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_ReferenceGuide.pdf) y el [Theory Manual](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_TheoryManual.pdf). Si copias estos PDF en la carpeta ``docs/`` (o los descargas con ``scripts/download_docs.py``), la búsqueda se realiza de forma local. Introduce una palabra clave y se muestran las primeras coincidencias encontradas. También se incluye un enlace directo para abrir el documento completo.
-
-> **Nota**: la búsqueda en PDF requiere la librería `PyPDF2`. Si no está instalada, la pestaña seguirá funcionando, pero la búsqueda mostrará un mensaje de aviso.
+La pestaña **Ayuda** ofrece enlaces directos a la documentación principal de Radioss: la [Reference Guide](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_ReferenceGuide.pdf), la [User Guide](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_UserGuide.pdf) y el [Theory Manual](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_TheoryManual.pdf). Puedes descargar estos PDF con ``scripts/download_docs.py`` para consultarlos sin conexión.

--- a/scripts/download_docs.py
+++ b/scripts/download_docs.py
@@ -13,10 +13,15 @@ THEORY_MANUAL_URL = (
     "https://2022.help.altair.com/2022/simulation/pdfs/radopen/"
     "AltairRadioss_2022_TheoryManual.pdf"
 )
+USER_GUIDE_URL = (
+    "https://2022.help.altair.com/2022/simulation/pdfs/radopen/"
+    "AltairRadioss_2022_UserGuide.pdf"
+)
 
 PDFS = {
     REFERENCE_GUIDE_URL: "AltairRadioss_2022_ReferenceGuide.pdf",
     THEORY_MANUAL_URL: "AltairRadioss_2022_TheoryManual.pdf",
+    USER_GUIDE_URL: "AltairRadioss_2022_UserGuide.pdf",
 }
 
 

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -42,11 +42,9 @@ from cdb2rad.writer_inc import write_mesh_inc
 from cdb2rad.rad_validator import validate_rad_format
 from cdb2rad.utils import check_rad_inputs
 from cdb2rad.pdf_search import (
-    REFERENCE_GUIDE,
     REFERENCE_GUIDE_URL,
-    THEORY_MANUAL,
     THEORY_MANUAL_URL,
-    search_pdf,
+    USER_GUIDE as USER_GUIDE_URL,
 )
 
 MAX_EDGES = 10000
@@ -973,52 +971,13 @@ if file_path:
                 lines = rad_path.read_text().splitlines()[:20]
                 st.code("\n".join(lines))
 
-    # Documentation search with dynamic manual selection
+    # Documentation links
     with help_tab:
-        st.subheader("Buscar en documentación")
-        doc_choice = st.selectbox(
-
-            "Documento",
-            ["Reference Guide", "User Guide", "Theory Manual"],
-
+        st.subheader("Documentación")
+        st.markdown(
+            f"[Reference Guide]({REFERENCE_GUIDE_URL}) | "
+            f"[User Guide]({USER_GUIDE_URL}) | "
+            f"[Theory Manual]({THEORY_MANUAL_URL})"
         )
-        query = st.text_input("Término de búsqueda")
-        if st.button("Buscar", key="search_docs") and query:
-            if doc_choice == "Reference Guide":
-
-                source = (
-                    REFERENCE_GUIDE
-                    if REFERENCE_GUIDE.exists()
-                    else REFERENCE_GUIDE_URL
-                )
-                link = REFERENCE_GUIDE_URL
-            else:
-                source = (
-                    THEORY_MANUAL
-                    if THEORY_MANUAL.exists()
-                    else THEORY_MANUAL_URL
-                )
-                link = THEORY_MANUAL_URL
-            try:
-                results = search_pdf(source, query)
-            except ImportError:
-                st.error("PyPDF2 no está instalado. Instala la dependencia para habilitar la búsqueda.")
-                results = []
-            except Exception as e:  # pragma: no cover - network errors
-                st.error(f"No se pudo buscar en el PDF: {e}")
-                results = []
-
-            if results:
-                for r in results:
-                    st.write(r)
-            elif results == []:
-                st.warning("Sin coincidencias")
-
-        else:
-            link = (
-                REFERENCE_GUIDE_URL if doc_choice == "Reference Guide" else THEORY_MANUAL_URL
-            )
-
-        st.markdown(f"[Abrir {doc_choice}]({link})")
 else:
     st.info("Sube un archivo .cdb")


### PR DESCRIPTION
## Summary
- simplify dashboard help section without PDF search
- link Reference Guide, User Guide and Theory Manual directly
- update README help instructions
- allow downloading User Guide via script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d089fe5ec8327ba8689e3da38f8f9