### PR TITLE
Fix ADYREL block output

### DIFF
--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -134,12 +134,11 @@ def write_rad(
             else:
                 f.write("/RFILE\n")
             f.write(f"{rfile_cycle}\n")
-        if adyrel is not None:
+        if adyrel is not None and (adyrel[0] is not None or adyrel[1] is not None):
             f.write("/ADYREL\n")
-            if adyrel[0] is not None or adyrel[1] is not None:
-                tstart = 0.0 if adyrel[0] is None else adyrel[0]
-                tstop = t_end if adyrel[1] is None else adyrel[1]
-                f.write(f"{tstart} {tstop}\n")
+            tstart = 0.0 if adyrel[0] is None else adyrel[0]
+            tstop = t_end if adyrel[1] is None else adyrel[1]
+            f.write(f"{tstart} {tstop}\n")
 
         # 2. MATERIALS
         def write_law1(mid: int, name: str, rho: float, e: float, nu: float) -> None:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -236,6 +236,14 @@ def test_write_rad_advanced_options(tmp_path):
     assert '/ADYREL' in text
 
 
+def test_write_rad_adyrel_none(tmp_path):
+    nodes, elements, *_ = parse_cdb(DATA)
+    rad = tmp_path / 'adyrel_none.rad'
+    write_rad(nodes, elements, str(rad), adyrel=(None, None))
+    txt = rad.read_text()
+    assert '/ADYREL' not in txt
+
+
 def test_write_rad_without_include(tmp_path):
     nodes, elements, *_ = parse_cdb(DATA)
     rad = tmp_path / 'noinc.rad'


### PR DESCRIPTION
## Summary
- skip empty `/ADYREL` section in writer
- test that a `(None, None)` tuple does not emit `/ADYREL`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d099454288327bbe3e312e8f0937b