### PR TITLE
Add remote point creation to dashboard

### DIFF
--- a/cdb2rad/__init__.py
+++ b/cdb2rad/__init__.py
@@ -4,6 +4,7 @@ from .parser import parse_cdb
 from .writer_inc import write_mesh_inc
 from .writer_rad import write_rad, write_minimal_rad
 from .utils import element_summary
+from .remote import add_remote_point, next_free_node_id
 from .material_defaults import apply_default_materials
 
 __all__ = [
@@ -13,4 +14,6 @@ __all__ = [
     "write_minimal_rad",
     "element_summary",
     "apply_default_materials",
+    "add_remote_point",
+    "next_free_node_id",
 ]

--- a/cdb2rad/remote.py
+++ b/cdb2rad/remote.py
@@ -1,0 +1,24 @@
+from typing import Dict, List, Tuple
+
+
+def next_free_node_id(nodes: Dict[int, List[float]]) -> int:
+    """Return the next available node ID not used in *nodes*."""
+    nid = max(nodes.keys(), default=0) + 1
+    while nid in nodes:
+        nid += 1
+    return nid
+
+
+def add_remote_point(
+    nodes: Dict[int, List[float]],
+    coords: Tuple[float, float, float],
+    node_id: int | None = None,
+) -> Tuple[Dict[int, List[float]], int]:
+    """Return a new node dictionary including a remote point."""
+    if node_id is None:
+        node_id = next_free_node_id(nodes)
+    elif node_id in nodes:
+        raise ValueError("Node ID already exists")
+    new_nodes = dict(nodes)
+    new_nodes[node_id] = list(coords)
+    return new_nodes, node_id

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -48,6 +48,7 @@ from cdb2rad.writer_rad import (
 from cdb2rad.writer_inc import write_mesh_inc
 from cdb2rad.rad_validator import validate_rad_format
 from cdb2rad.utils import check_rad_inputs
+from cdb2rad.remote import add_remote_point, next_free_node_id
 from cdb2rad.pdf_search import (
     REFERENCE_GUIDE_URL,
     THEORY_MANUAL_URL,
@@ -504,6 +505,18 @@ if file_path:
             st.session_state["rbe2"] = []
         if "rbe3" not in st.session_state:
             st.session_state["rbe3"] = []
+        if "remote_points" not in st.session_state:
+            st.session_state["remote_points"] = []
+
+        extra_nodes = {
+            rp["id"]: list(rp["coords"])
+            for rp in st.session_state["remote_points"]
+        }
+        all_nodes = {**nodes, **extra_nodes}
+        extra_sets = {
+            f"REMOTE_{rp['id']}": [rp['id']] for rp in st.session_state["remote_points"]
+        }
+        all_node_sets = {**node_sets, **extra_sets}
 
         with st.expander("Definición de materiales"):
             use_cdb_mats = st.checkbox("Incluir materiales del CDB", value=False)
@@ -688,8 +701,8 @@ if file_path:
             st.caption(BC_DESCRIPTIONS[bc_type])
             bc_set = st.selectbox(
                 "Conjunto de nodos",
-                list(node_sets.keys()),
-                disabled=not node_sets,
+                list(all_node_sets.keys()),
+                disabled=not all_node_sets,
             )
             bc_data = {}
             if bc_type == "BCS":
@@ -702,7 +715,7 @@ if file_path:
                 bc_data.update({"dir": int(bc_dir), "value": float(bc_val)})
 
             if st.button("Añadir BC") and bc_set:
-                node_list = node_sets.get(bc_set, [])
+                node_list = all_node_sets.get(bc_set, [])
                 entry = {
                     "name": bc_name,
                     "type": bc_type,
@@ -731,15 +744,15 @@ if file_path:
             int_name = st.text_input("Nombre interfaz", value=f"{int_type}_1")
             slave_set = st.selectbox(
                 "Conjunto esclavo",
-                list(node_sets.keys()),
+                list(all_node_sets.keys()),
                 key="slave_set",
-                disabled=not node_sets,
+                disabled=not all_node_sets,
             )
             master_set = st.selectbox(
                 "Conjunto maestro",
-                list(node_sets.keys()),
+                list(all_node_sets.keys()),
                 key="master_set",
-                disabled=not node_sets,
+                disabled=not all_node_sets,
             )
             fric = input_with_help("Fricción", 0.0, "fric")
 
@@ -750,8 +763,8 @@ if file_path:
                 igap = input_with_help("Igap", 0, "igap")
 
             if st.button("Añadir interfaz") and slave_set and master_set:
-                s_list = node_sets.get(slave_set, [])
-                m_list = node_sets.get(master_set, [])
+                s_list = all_node_sets.get(slave_set, [])
+                m_list = all_node_sets.get(master_set, [])
                 itf = {
                     "type": int_type,
                     "name": int_name,
@@ -778,15 +791,15 @@ if file_path:
         with st.expander("Velocidad inicial (IMPVEL)"):
             vel_set = st.selectbox(
                 "Conjunto de nodos",
-                list(node_sets.keys()),
+                list(all_node_sets.keys()),
                 key="vel_set",
-                disabled=not node_sets,
+                disabled=not all_node_sets,
             )
             vx = input_with_help("Vx", 0.0, "vx")
             vy = input_with_help("Vy", 0.0, "vy")
             vz = input_with_help("Vz", 0.0, "vz")
             if st.button("Asignar velocidad") and vel_set:
-                n_list = node_sets.get(vel_set, [])
+                n_list = all_node_sets.get(vel_set, [])
                 st.session_state["init_vel"] = {
                     "nodes": n_list,
                     "vx": vx,
@@ -823,6 +836,36 @@ if file_path:
                 with cols[1]:
                     if st.button("Eliminar", key="del_gravity"):
                         st.session_state["gravity"] = None
+                        _rerun()
+
+        with st.expander("Puntos remotos"):
+            colx, coly, colz = st.columns(3)
+            with colx:
+                rx = st.number_input("X", 0.0, key="rp_x")
+            with coly:
+                ry = st.number_input("Y", 0.0, key="rp_y")
+            with colz:
+                rz = st.number_input("Z", 0.0, key="rp_z")
+            auto = st.checkbox("ID automático", value=True, key="rp_auto")
+            next_id = next_free_node_id(all_nodes)
+            rid = st.number_input("ID", value=next_id, key="rp_id", disabled=auto)
+            if st.button("Añadir punto remoto"):
+                try:
+                    if auto:
+                        _, nid = add_remote_point(all_nodes, (rx, ry, rz))
+                    else:
+                        _, nid = add_remote_point(all_nodes, (rx, ry, rz), int(rid))
+                    st.session_state["remote_points"].append({"id": nid, "coords": (rx, ry, rz)})
+                    _rerun()
+                except ValueError as e:
+                    st.error(str(e))
+            for i, rp in enumerate(st.session_state.get("remote_points", [])):
+                cols = st.columns([4, 1])
+                with cols[0]:
+                    st.write(f"ID {rp['id']} → {rp['coords']}")
+                with cols[1]:
+                    if st.button("Eliminar", key=f"del_rp_{i}"):
+                        st.session_state["remote_points"].pop(i)
                         _rerun()
 
         rad_dir = st.text_input(
@@ -873,7 +916,7 @@ if file_path:
                 st.error("El archivo ya existe. Elija otro nombre o directorio")
             else:
                 if no_opts:
-                    write_mesh_inc(nodes, elements, str(mesh_path))
+                    write_mesh_inc(all_nodes, elements, str(mesh_path), node_sets=all_node_sets)
                     from cdb2rad.writer_rad import write_minimal_rad
                     write_minimal_rad(
                         str(rad_path),
@@ -909,14 +952,14 @@ if file_path:
                         adyrel_start = ctrl.get("adyrel_start", adyrel_start)
                         adyrel_stop = ctrl.get("adyrel_stop", adyrel_stop)
                     if not include_inc:
-                        write_mesh_inc(nodes, elements, str(mesh_path))
+                        write_mesh_inc(all_nodes, elements, str(mesh_path), node_sets=all_node_sets)
                     write_rad(
-                        nodes,
+                        all_nodes,
                         elements,
                         str(rad_path),
                         mesh_inc=str(mesh_path),
                         include_inc=include_inc,
-                        node_sets=node_sets,
+                        node_sets=all_node_sets,
                         elem_sets=elem_sets,
                         materials=materials if use_cdb_mats else None,
                         extra_materials=extra,
@@ -978,7 +1021,7 @@ if file_path:
                 st.error("El archivo RAD ya existe. Cambie el nombre o directorio")
 
             else:
-                write_mesh_inc(nodes, elements, str(mesh_path))
+                write_mesh_inc(all_nodes, elements, str(mesh_path), node_sets=all_node_sets)
                 from cdb2rad.writer_rad import write_minimal_rad
 
                 write_minimal_rad(
@@ -996,8 +1039,8 @@ if file_path:
         st.subheader("Rigid Connectors")
         with st.expander("/RBODY"):
             rb_id = st.number_input("RBID", 1)
-            master = st.selectbox("Nodo maestro", list(nodes.keys()))
-            slaves = st.multiselect("Nodos secundarios", list(nodes.keys()))
+            master = st.selectbox("Nodo maestro", list(all_nodes.keys()))
+            slaves = st.multiselect("Nodos secundarios", list(all_nodes.keys()))
             if st.button("Añadir RBODY"):
                 st.session_state["rbodies"].append({
                     "RBID": int(rb_id),
@@ -1011,8 +1054,8 @@ if file_path:
                 st.experimental_rerun()
 
         with st.expander("/RBE2"):
-            m = st.selectbox("Master", list(nodes.keys()), key="rbe2m")
-            slaves2 = st.multiselect("Slaves", list(nodes.keys()), key="rbe2s")
+            m = st.selectbox("Master", list(all_nodes.keys()), key="rbe2m")
+            slaves2 = st.multiselect("Slaves", list(all_nodes.keys()), key="rbe2s")
             if st.button("Añadir RBE2"):
                 st.session_state["rbe2"].append({
                     "N_master": int(m),
@@ -1025,8 +1068,8 @@ if file_path:
                 st.experimental_rerun()
 
         with st.expander("/RBE3"):
-            dep = st.selectbox("Dependiente", list(nodes.keys()), key="rbe3d")
-            indep_nodes = st.multiselect("Independientes", list(nodes.keys()), key="rbe3i")
+            dep = st.selectbox("Dependiente", list(all_nodes.keys()), key="rbe3d")
+            indep_nodes = st.multiselect("Independientes", list(all_nodes.keys()), key="rbe3i")
             if st.button("Añadir RBE3"):
                 st.session_state["rbe3"].append({
                     "N_dependent": int(dep),

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,0 +1,23 @@
+from cdb2rad.remote import add_remote_point, next_free_node_id
+
+
+def test_next_free_id():
+    nodes = {1: [0.0, 0.0, 0.0], 3: [1.0, 0.0, 0.0]}
+    nid = next_free_node_id(nodes)
+    assert nid not in nodes
+
+
+def test_add_remote_point_auto():
+    nodes = {1: [0.0, 0.0, 0.0]}
+    new_nodes, nid = add_remote_point(nodes, (1.0, 2.0, 3.0))
+    assert nid in new_nodes and new_nodes[nid] == [1.0, 2.0, 3.0]
+    assert 1 in new_nodes
+    assert nid != 1
+
+
+def test_add_remote_point_manual():
+    nodes = {1: [0.0, 0.0, 0.0]}
+    new_nodes, nid = add_remote_point(nodes, (0.0, 1.0, 0.0), node_id=5)
+    assert nid == 5
+    assert new_nodes[5] == [0.0, 1.0, 0.0]
+


### PR DESCRIPTION
## Summary
- add `remote` module with helpers to create loose nodes
- expose new functions via package `__all__`
- integrate *puntos remotos* section in dashboard with automatic ID logic
- include remote nodes when generating `rad` and connectors
- test remote node utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d10e35cac83278211bd4799fe1434