### PR TITLE
Add unified rigid connector options

### DIFF
--- a/cdb2rad/rad_validator.py
+++ b/cdb2rad/rad_validator.py
@@ -48,6 +48,8 @@ KEYWORDS = (
     "/GRNOD/BOX/",
     "/BOX/RECTA/",
     "/RBODY/",
+    "/RBE2/",
+    "/RBE3/",
     "/TH/",
     "/FUNCT/",
 )
@@ -149,6 +151,24 @@ def validate_rad_format(filepath: str) -> None:
             if not lines[i + 2].startswith("/FRICTION"):
                 raise ValueError("TYPE2 missing /FRICTION")
             i += 4
+            continue
+
+        if line.startswith("/RBODY/"):
+            if i + 7 >= len(lines):
+                raise ValueError("Incomplete /RBODY block")
+            i += 8
+            continue
+
+        if line.startswith("/RBE2/"):
+            if i + 4 >= len(lines):
+                raise ValueError("Incomplete /RBE2 block")
+            i += 5
+            continue
+
+        if line.startswith("/RBE3/"):
+            if i + 5 >= len(lines):
+                raise ValueError("Incomplete /RBE3 block")
+            i += 6
             continue
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -244,3 +244,33 @@ def test_write_rad_without_include(tmp_path):
     assert '#include' not in content
 
 
+def test_write_rad_with_connectors(tmp_path):
+    nodes, elements, *_ = parse_cdb(DATA)
+    rad = tmp_path / 'conn.rad'
+    cons = [
+        {
+            'type': 'RBODY',
+            'RBID': 1,
+            'Gnod_id': list(nodes.keys())[0],
+            'nodes': [list(nodes.keys())[1]],
+        },
+        {
+            'type': 'RBE2',
+            'name': 'c2',
+            'N_master': list(nodes.keys())[0],
+            'N_slave_list': [list(nodes.keys())[1]],
+        },
+        {
+            'type': 'RBE3',
+            'name': 'c3',
+            'N_dependent': list(nodes.keys())[0],
+            'independent': [(list(nodes.keys())[1], 1.0)],
+        },
+    ]
+    write_rad(nodes, elements, str(rad), connectors=cons)
+    text = rad.read_text()
+    assert '/RBODY/1' in text
+    assert '/RBE2/1' in text
+    assert '/RBE3/1' in text
+
+


### PR DESCRIPTION
## Summary
- integrate rigid connectors inside main RAD generation
- consolidate RBODY/RBE2/RBE3 definitions under a single list
- adapt dashboard to add connectors within the general RAD tab
- update tests to match new connector API

## Testing
- `flake8 | head -n 20`
- `pytest -q`
- `mypy cdb2rad src | head -n 20` *(fails: List comprehension has incompatible type; 29 errors)*
- `bandit -r cdb2rad -q | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_685d0af1312883278eaaba5439fb50d0