### PR TITLE
Remove default part section

### DIFF
--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -149,7 +149,6 @@ def write_rad(
         f.write("                  kg                  mm                   s\n")
         f.write("                  kg                  mm                   s\n")
 
-        f.write("/PART/1/1/1\n")
         # General printout frequency
         f.write(f"/PRINT/{print_n}/{print_line}\n")
         f.write(f"/RUN/{runname}/1/\n")
@@ -439,9 +438,7 @@ def write_rad(
                 for nid, wt in rb.get('independent', []):
                     f.write(f"   {nid}     {wt}\n")
 
-        # 5. PARTS
-        f.write(f"/PART/1/1/1\n")
-        f.write(f"/PROP/SHELL/1 {thickness} 0\n")
+        # 5. PARTS -- explicit part definitions are omitted by default
 
         if init_velocity:
             nodes_v = init_velocity.get("nodes", [])

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -69,7 +69,6 @@ def test_write_rad(tmp_path):
     assert content.startswith('#RADIOSS STARTER')
     assert '/BEGIN' in content
     assert '/END' in content
-    assert '2.0' in content
     assert '100000.0' in content
 
     assert '/STOP' in content


### PR DESCRIPTION
## Summary
- stop writer_rad from adding `/PART/1/1/1` and `/PROP/SHELL/1` by default
- adapt basic test accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d118f0afc8327b2cf2f497953634c