### PR TITLE
Add remote point labels and mass

### DIFF
--- a/cdb2rad/__init__.py
+++ b/cdb2rad/__init__.py
@@ -4,6 +4,7 @@ from .parser import parse_cdb
 from .writer_inc import write_mesh_inc
 from .writer_rad import write_rad, write_minimal_rad
 from .utils import element_summary
+from .remote import add_remote_point, next_free_node_id
 from .material_defaults import apply_default_materials
 
 __all__ = [
@@ -13,4 +14,6 @@ __all__ = [
     "write_minimal_rad",
     "element_summary",
     "apply_default_materials",
+    "add_remote_point",
+    "next_free_node_id",
 ]

--- a/cdb2rad/remote.py
+++ b/cdb2rad/remote.py
@@ -1,0 +1,34 @@
+from typing import Dict, List, Tuple
+
+
+def next_free_node_id(nodes: Dict[int, List[float]]) -> int:
+    """Return the next available node ID not used in *nodes*."""
+    nid = max(nodes.keys(), default=0) + 1
+    while nid in nodes:
+        nid += 1
+    return nid
+
+
+def add_remote_point(
+    nodes: Dict[int, List[float]],
+    coords: Tuple[float, float, float],
+    *,
+    node_id: int | None = None,
+    label: str | None = None,
+    mass: float | None = None,
+) -> Tuple[Dict[int, List[float]], Dict[str, object]]:
+    """Return updated nodes and remote point metadata."""
+    if node_id is None:
+        node_id = next_free_node_id(nodes)
+    elif node_id in nodes:
+        raise ValueError("Node ID already exists")
+    new_nodes = dict(nodes)
+    new_nodes[node_id] = list(coords)
+    rp = {
+        "id": node_id,
+        "coords": coords,
+        "label": label or f"REMOTE_{node_id}",
+    }
+    if mass is not None:
+        rp["mass"] = float(mass)
+    return new_nodes, rp

--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -75,6 +75,7 @@ def write_rad(
     rbe3: List[Dict[str, object]] | None = None,
     init_velocity: Dict[str, object] | None = None,
     gravity: Dict[str, float] | None = None,
+    remote_points: List[Dict[str, object]] | None = None,
 
 ) -> None:
     """Generate ``model_0000.rad`` with optional solver controls.
@@ -466,6 +467,17 @@ def write_rad(
             f.write("/GRAVITY\n")
             f.write(f"{comp} {g}\n")
             f.write(f"{nx} {ny} {nz}\n")
+
+        if remote_points:
+            for idx, rp in enumerate(remote_points, start=1):
+                mass = rp.get("mass")
+                if mass is None:
+                    continue
+                label = rp.get("label", f"REMOTE_{rp['id']}")
+                f.write(f"/INERTIA/PRINC/{idx}\n")
+                f.write(f"{label}\n")
+                f.write(f"{rp['id']}\n")
+                f.write(f"{mass} 0 0 0 0 0 0\n")
 
         f.write("/END\n")
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -277,3 +277,18 @@ def test_write_rad_with_connectors(tmp_path):
     assert '/RBE3/1' in text
 
 
+def test_write_rad_remote_mass(tmp_path):
+    nodes, elements, *_ = parse_cdb(DATA)
+    rad = tmp_path / 'rmass.rad'
+    rp = [{
+        'id': max(nodes) + 1,
+        'coords': (0.0, 0.0, 1.0),
+        'label': 'Punto',
+        'mass': 5.0,
+    }]
+    write_rad(nodes, elements, str(rad), remote_points=rp)
+    content = rad.read_text()
+    assert '/INERTIA/PRINC/1' in content
+    assert '5.0 0 0 0 0 0 0' in content
+
+

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,0 +1,25 @@
+from cdb2rad.remote import add_remote_point, next_free_node_id
+
+
+def test_next_free_id():
+    nodes = {1: [0.0, 0.0, 0.0], 3: [1.0, 0.0, 0.0]}
+    nid = next_free_node_id(nodes)
+    assert nid not in nodes
+
+
+def test_add_remote_point_auto():
+    nodes = {1: [0.0, 0.0, 0.0]}
+    new_nodes, rp = add_remote_point(nodes, (1.0, 2.0, 3.0))
+    assert rp["id"] in new_nodes and new_nodes[rp["id"]] == [1.0, 2.0, 3.0]
+    assert rp["id"] != 1
+    assert rp["label"] == f"REMOTE_{rp['id']}"
+
+
+def test_add_remote_point_manual():
+    nodes = {1: [0.0, 0.0, 0.0]}
+    new_nodes, rp = add_remote_point(nodes, (0.0, 1.0, 0.0), node_id=5, label="P1", mass=2.0)
+    assert rp["id"] == 5
+    assert new_nodes[5] == [0.0, 1.0, 0.0]
+    assert rp["label"] == "P1"
+    assert rp["mass"] == 2.0
+


### PR DESCRIPTION
## Summary
- expand `add_remote_point` to return metadata with optional label and mass
- allow setting label/mass in dashboard and include them when generating `rad`
- write `/INERTIA/PRINC` blocks for remote point masses
- test new remote utilities and starter output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d10e35cac83278211bd4799fe1434