### PR TITLE
Add ParaView Web preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,3 +181,18 @@ del archivo para guardar fácilmente los resultados.
 ### Ayuda interactiva
 
 La pestaña **Ayuda** ofrece enlaces directos a la documentación principal de Radioss: la [Reference Guide](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_ReferenceGuide.pdf), la [User Guide](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_UserGuide.pdf) y el [Theory Manual](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_TheoryManual.pdf). Puedes descargar estos PDF con ``scripts/download_docs.py`` para consultarlos sin conexión.
+
+### Vista 3D con ParaView Web
+
+Para una visualización más completa de la malla se puede utilizar un servidor
+**ParaView Web**. Con ``scripts/start_paraview_web.py`` se genera un fichero
+``.vtk`` temporal a partir del ``.cdb`` y se lanza el visualizador de ParaView
+en el puerto 12345 por defecto:
+
+```bash
+python scripts/start_paraview_web.py data_files/model.cdb
+```
+
+Al ejecutar el comando se mostrará la URL del visualizador. Desde la pestaña
+**Vista 3D** del dashboard se puede abrir dicho enlace para inspeccionar la malla
+con todas las herramientas de ParaView.

--- a/cdb2rad/vtk_writer.py
+++ b/cdb2rad/vtk_writer.py
@@ -1,0 +1,44 @@
+"""Simple VTK writer for the web viewer."""
+from typing import Dict, List, Tuple
+
+
+def write_vtk(
+    nodes: Dict[int, List[float]],
+    elements: List[Tuple[int, int, List[int]]],
+    outfile: str,
+) -> None:
+    """Write an ASCII VTK UnstructuredGrid file."""
+    # map node ids to 0-based indices
+    id_map = {nid: i for i, nid in enumerate(sorted(nodes))}
+
+    with open(outfile, "w") as f:
+        f.write("# vtk DataFile Version 3.0\n")
+        f.write("cdb2rad mesh\n")
+        f.write("ASCII\n")
+        f.write("DATASET UNSTRUCTURED_GRID\n")
+        f.write(f"POINTS {len(nodes)} float\n")
+        for nid in sorted(nodes):
+            x, y, z = nodes[nid]
+            f.write(f"{x} {y} {z}\n")
+
+        total = sum(len(e[2]) + 1 for e in elements)
+        f.write(f"\nCELLS {len(elements)} {total}\n")
+        for _, _, nids in elements:
+            mapped = [id_map[n] for n in nids if n in id_map]
+            f.write(str(len(mapped)) + " " + " ".join(str(i) for i in mapped) + "\n")
+
+        f.write(f"\nCELL_TYPES {len(elements)}\n")
+        for _, _, nids in elements:
+            l = len(nids)
+            if l == 3:
+                ctype = 5  # TRIANGLE
+            elif l == 4:
+                ctype = 9  # QUAD
+            elif l in (8, 20):
+                ctype = 12  # HEXAHEDRON
+            elif l == 10:
+                ctype = 10  # TETRA
+            else:
+                ctype = 7  # POLYGON
+            f.write(f"{ctype}\n")
+

--- a/scripts/start_paraview_web.py
+++ b/scripts/start_paraview_web.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Launch ParaView Web Visualizer for a .cdb mesh."""
+import argparse
+import subprocess
+import tempfile
+from pathlib import Path
+
+from cdb2rad.parser import parse_cdb
+from cdb2rad.vtk_writer import write_vtk
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Start ParaView Web server")
+    parser.add_argument("cdb_file", help="Input .cdb file")
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=12345,
+        help="Port for the web server",
+    )
+    args = parser.parse_args()
+
+    nodes, elements, *_ = parse_cdb(args.cdb_file)
+
+    tmp_dir = tempfile.mkdtemp()
+    vtk_path = Path(tmp_dir) / "mesh.vtk"
+    write_vtk(nodes, elements, str(vtk_path))
+
+    cmd = [
+        "pvpython",
+        "-m",
+        "paraview.web.visualizer",
+        "--data",
+        str(vtk_path),
+        "--port",
+        str(args.port),
+    ]
+
+    print(
+        f"Starting ParaView Web Visualizer at http://localhost:{args.port}/ (Ctrl+C to stop)"
+    )
+    subprocess.run(cmd, check=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import sys
 import json
 import math
+import subprocess
 from typing import Dict, List, Tuple, Optional, Set
 
 # Ensure repository root is on the Python path before importing local modules
@@ -18,6 +19,13 @@ def _rerun():
         st.rerun()
     elif hasattr(st, "experimental_rerun"):
         st.experimental_rerun()
+
+
+def launch_paraview_server(cdb_path: str, port: int = 12345) -> str:
+    """Spawn ParaView Web server for the given CDB file."""
+    script = Path(__file__).resolve().parents[2] / "scripts" / "start_paraview_web.py"
+    subprocess.Popen(["python", str(script), cdb_path, "--port", str(port)])
+    return f"http://localhost:{port}/"
 
 SDEA_LOGO_URL = (
     "https://sdeasolutions.com/wp-content/uploads/2021/11/"
@@ -445,6 +453,11 @@ if file_path:
                 "elementos para agilizar la vista"
             )
         st.components.v1.html(html, height=420)
+        if st.button("Abrir en ParaView Web"):
+            url = launch_paraview_server(file_path)
+            st.session_state["pvw_url"] = url
+        if "pvw_url" in st.session_state:
+            st.markdown(f"[Abrir ParaView]({st.session_state['pvw_url']})")
 
     with inp_tab:
         st.subheader("Generar mesh.inc")

--- a/tests/test_vtk_writer.py
+++ b/tests/test_vtk_writer.py
@@ -1,0 +1,18 @@
+from cdb2rad.parser import parse_cdb
+from cdb2rad.vtk_writer import write_vtk
+import os
+import tempfile
+
+DATA = os.path.join(os.path.dirname(__file__), '..', 'data', 'model.cdb')
+
+
+def test_write_vtk():
+    nodes, elements, *_ = parse_cdb(DATA)
+    with tempfile.NamedTemporaryFile(delete=False, suffix='.vtk') as tmp:
+        write_vtk(nodes, elements, tmp.name)
+        tmp.close()
+        with open(tmp.name, 'r') as f:
+            content = f.read()
+    assert content.startswith('# vtk DataFile')
+    assert 'DATASET UNSTRUCTURED_GRID' in content
+


### PR DESCRIPTION
## Summary
- create `vtk_writer` to export meshes to VTK
- add script `start_paraview_web.py` that launches ParaView Web Visualizer
- integrate a new button in the dashboard to open the server
- document usage in README
- test VTK writer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d2a3fafcc8327bdf615549f23f8ea