### PR TITLE
Allow disabling solver blocks

### DIFF
--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -52,12 +52,12 @@ def write_rad(
 
     runname: str = DEFAULT_RUNNAME,
     t_end: float = DEFAULT_FINAL_TIME,
-    anim_dt: float = DEFAULT_ANIM_DT,
-    tfile_dt: float = DEFAULT_HISTORY_DT,
-    dt_ratio: float = DEFAULT_DT_RATIO,
+    anim_dt: float | None = DEFAULT_ANIM_DT,
+    tfile_dt: float | None = DEFAULT_HISTORY_DT,
+    dt_ratio: float | None = DEFAULT_DT_RATIO,
     # Additional engine control options
-    print_n: int = DEFAULT_PRINT_N,
-    print_line: int = DEFAULT_PRINT_LINE,
+    print_n: int | None = DEFAULT_PRINT_N,
+    print_line: int | None = DEFAULT_PRINT_LINE,
     rfile_cycle: int | None = None,
     rfile_n: int | None = None,
     h3d_dt: float | None = None,
@@ -81,8 +81,10 @@ def write_rad(
 
     Parameters allow customizing material properties and basic engine
     settings such as final time, animation frequency and time-step
-    controls. Gravity loading can be specified via the ``gravity``
-    parameter. Set ``include_inc`` to ``False`` to omit the
+    controls. Pass ``None`` for ``anim_dt``, ``tfile_dt``, ``dt_ratio``,
+    ``print_n`` or ``print_line`` to omit the corresponding block in
+    the generated file. Gravity loading can be specified via the
+    ``gravity`` parameter. Set ``include_inc`` to ``False`` to omit the
     ``#include`` line referencing the mesh.
     """
 
@@ -150,20 +152,24 @@ def write_rad(
         f.write("                  kg                  mm                   s\n")
 
         # General printout frequency
-        f.write(f"/PRINT/{print_n}/{print_line}\n")
+        if print_n is not None and print_line is not None:
+            f.write(f"/PRINT/{print_n}/{print_line}\n")
         f.write(f"/RUN/{runname}/1/\n")
         f.write(f"                {t_end}\n")
         f.write("/STOP\n")
         f.write(
             f"{stop_emax} {stop_mmax} {stop_nmax} {stop_nth} {stop_nanim} {stop_nerr}\n"
         )
-        f.write("/TFILE/0\n")
-        f.write(f"{tfile_dt}\n")
+        if tfile_dt is not None:
+            f.write("/TFILE/0\n")
+            f.write(f"{tfile_dt}\n")
         f.write("/VERS/2024\n")
-        f.write("/DT/NODA/CST/0\n")
-        f.write(f"{dt_ratio} 0 0\n")
-        f.write("/ANIM/DT\n")
-        f.write(f"0 {anim_dt}\n")
+        if dt_ratio is not None:
+            f.write("/DT/NODA/CST/0\n")
+            f.write(f"{dt_ratio} 0 0\n")
+        if anim_dt is not None:
+            f.write("/ANIM/DT\n")
+            f.write(f"0 {anim_dt}\n")
         if h3d_dt is not None:
             f.write("/H3D/DT\n")
             f.write(f"0 {h3d_dt}\n")

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -617,18 +617,31 @@ if file_path:
                 "Nombre de la simulación", value=DEFAULT_RUNNAME
             )
             t_end = input_with_help("Tiempo final", DEFAULT_FINAL_TIME, "t_end")
-            anim_dt = input_with_help("Paso animación", DEFAULT_ANIM_DT, "anim_dt")
-            tfile_dt = input_with_help("Intervalo historial", DEFAULT_HISTORY_DT, "tfile_dt")
-            dt_ratio = input_with_help(
-                "Factor seguridad DT",
-                DEFAULT_DT_RATIO,
-                "dt_ratio",
-            )
+            if st.checkbox("Definir paso animación", key="en_anim"):
+                anim_dt = input_with_help("Paso animación", DEFAULT_ANIM_DT, "anim_dt")
+            else:
+                anim_dt = None
+            if st.checkbox("Definir intervalo historial", key="en_tfile"):
+                tfile_dt = input_with_help("Intervalo historial", DEFAULT_HISTORY_DT, "tfile_dt")
+            else:
+                tfile_dt = None
+            if st.checkbox("Definir factor seguridad DT", key="en_dt"):
+                dt_ratio = input_with_help(
+                    "Factor seguridad DT",
+                    DEFAULT_DT_RATIO,
+                    "dt_ratio",
+                )
+            else:
+                dt_ratio = None
             adv_enabled = st.checkbox("Activar opciones avanzadas")
             if adv_enabled:
                 st.markdown("### Opciones avanzadas")
-                print_n = input_with_help("PRINT cada n ciclos", DEFAULT_PRINT_N, "print_n")
-                print_line = input_with_help("Línea cabecera", DEFAULT_PRINT_LINE, "print_line")
+                if st.checkbox("Definir /PRINT", key="en_print"):
+                    print_n = input_with_help("PRINT cada n ciclos", DEFAULT_PRINT_N, "print_n")
+                    print_line = input_with_help("Línea cabecera", DEFAULT_PRINT_LINE, "print_line")
+                else:
+                    print_n = None
+                    print_line = None
                 rfile_cycle = input_with_help("Ciclos entre RFILE", 0, "rfile_cycle")
                 rfile_n = input_with_help("Número de RFILE", 0, "rfile_n")
                 h3d_dt = input_with_help("Paso H3D", 0.0, "h3d_dt")
@@ -649,8 +662,8 @@ if file_path:
                 adyrel_start = input_with_help("ADYREL inicio", 0.0, "adyrel_start")
                 adyrel_stop = input_with_help("ADYREL fin", 0.0, "adyrel_stop")
             else:
-                print_n = DEFAULT_PRINT_N
-                print_line = DEFAULT_PRINT_LINE
+                print_n = None
+                print_line = None
                 rfile_cycle = 0
                 rfile_n = 0
                 h3d_dt = 0.0
@@ -670,8 +683,8 @@ if file_path:
                     "anim_dt": anim_dt,
                     "tfile_dt": tfile_dt,
                     "dt_ratio": dt_ratio,
-                    "print_n": int(print_n),
-                    "print_line": int(print_line),
+                    "print_n": int(print_n) if print_n is not None else None,
+                    "print_line": int(print_line) if print_line is not None else None,
                     "rfile_cycle": int(rfile_cycle) if rfile_cycle else None,
                     "rfile_n": int(rfile_n) if rfile_n else None,
                     "h3d_dt": h3d_dt if h3d_dt > 0 else None,
@@ -1005,8 +1018,8 @@ if file_path:
                         anim_dt=anim_dt,
                         tfile_dt=tfile_dt,
                         dt_ratio=dt_ratio,
-                        print_n=int(print_n),
-                        print_line=int(print_line),
+                        print_n=int(print_n) if print_n is not None else None,
+                        print_line=int(print_line) if print_line is not None else None,
                         rfile_cycle=int(rfile_cycle) if rfile_cycle else None,
                         rfile_n=int(rfile_n) if rfile_n else None,
                         h3d_dt=h3d_dt if h3d_dt > 0 else None,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -240,6 +240,26 @@ def test_write_rad_without_include(tmp_path):
     assert '#include' not in content
 
 
+def test_write_rad_skip_controls(tmp_path):
+    nodes, elements, *_ = parse_cdb(DATA)
+    rad = tmp_path / 'skip.rad'
+    write_rad(
+        nodes,
+        elements,
+        str(rad),
+        anim_dt=None,
+        tfile_dt=None,
+        dt_ratio=None,
+        print_n=None,
+        print_line=None,
+    )
+    txt = rad.read_text()
+    assert '/ANIM/DT' not in txt
+    assert '/TFILE' not in txt
+    assert '/DT/NODA' not in txt
+    assert '/PRINT' not in txt
+
+
 def test_write_rad_with_connectors(tmp_path):
     nodes, elements, *_ = parse_cdb(DATA)
     rad = tmp_path / 'conn.rad'


### PR DESCRIPTION
## Summary
- support optional /PRINT, /TFILE, /DT and /ANIM controls
- dashboard leaves these parameters unset unless activated
- test writing RAD without these blocks

## Testing
- `pytest -q`
- `flake8` *(fails: command not found or warnings logged)*
- `mypy` *(failed: Missing target module)*
- `bandit -r .`

------
https://chatgpt.com/codex/tasks/task_e_685d2a55ee688327b0626a696179307e