### PR TITLE
Add ParaViewWeb viewer integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,17 +185,17 @@ La pestaña **Ayuda** ofrece enlaces directos a la documentación principal de R
 ### Vista 3D con ParaView Web
 
 Para una visualización más completa de la malla se puede utilizar un servidor
-**ParaView Web**. Con ``scripts/start_paraview_web.py`` se genera un fichero
-``.vtk`` temporal a partir del ``.cdb`` y se lanza el visualizador de ParaView
+**ParaView Web**. Con ``scripts/pv_visualizer.py`` se genera un fichero
+``.vtk`` temporal a partir del archivo de entrada y se lanza un servidor wslink
 en el puerto 12345 por defecto:
 
 ```bash
-python scripts/start_paraview_web.py data_files/model.cdb
+python scripts/pv_visualizer.py --data data_files/model.cdb --port 12345
 ```
 
 Al ejecutar el comando se mostrará la URL del visualizador. Desde la pestaña
-xfy9un-codex/añadir-servidor-web-paraview-para-visualización-3d
 **Vista 3D** del dashboard se puede iniciar el servidor y el visor quedará
-embebido directamente en la aplicación para inspeccionar la malla con todas
-las herramientas de ParaView.
+embebido directamente en la aplicación usando ``static/vtk_viewer.html`` para
+conectarse vía WebSocket y visualizar la malla con todas las herramientas de
+ParaView.
 

--- a/cdb2rad/mesh_convert.py
+++ b/cdb2rad/mesh_convert.py
@@ -1,0 +1,27 @@
+"""Utility to convert mesh files to VTK format for ParaViewWeb."""
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import meshio
+
+from .parser import parse_cdb
+from .vtk_writer import write_vtk
+
+
+SUPPORTED_EXT = {".cdb", ".inp", ".rad", ".inc", ".vtk", ".vtp", ".stl", ".obj"}
+
+
+def convert_to_vtk(infile: str, outfile: str) -> None:
+    """Convert ``infile`` to VTK format at ``outfile``.
+
+    If ``infile`` is a ``.cdb`` it is parsed using :func:`parse_cdb`. Other
+    formats are handled via :mod:`meshio`.
+    """
+    ext = Path(infile).suffix.lower()
+    if ext == ".cdb":
+        nodes, elements, *_ = parse_cdb(infile)
+        write_vtk(nodes, elements, outfile)
+        return
+
+    mesh = meshio.read(infile)
+    meshio.write(outfile, mesh)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ streamlit
 PyPDF2
 matplotlib
 numpy
+meshio
+vtk
+wslink

--- a/scripts/pv_visualizer.py
+++ b/scripts/pv_visualizer.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Minimal ParaViewWeb server using VTK and wslink."""
+
+import argparse
+from pathlib import Path
+
+from wslink import server
+from vtkmodules.web import protocols as vtkprotocols
+from vtkmodules.web import wslink as vtk_wslink
+
+import vtkmodules.all as vtk
+
+
+def build_view(path: str) -> vtk.vtkRenderWindow:
+    """Create a render window with the data from ``path``."""
+    ext = Path(path).suffix.lower()
+    if ext == '.stl':
+        reader = vtk.vtkSTLReader()
+    elif ext == '.obj':
+        reader = vtk.vtkOBJReader()
+    elif ext in {'.vtp', '.vtk'}:
+        reader = vtk.vtkGenericDataObjectReader()
+    else:
+        reader = vtk.vtkGenericDataObjectReader()
+    reader.SetFileName(path)
+    reader.Update()
+    mapper = vtk.vtkDataSetMapper()
+    mapper.SetInputConnection(reader.GetOutputPort())
+    actor = vtk.vtkActor()
+    actor.SetMapper(mapper)
+    renderer = vtk.vtkRenderer()
+    renderer.AddActor(actor)
+    view = vtk.vtkRenderWindow()
+    view.AddRenderer(renderer)
+    return view
+
+
+class PVWServer(vtk_wslink.ServerProtocol):
+    """Server protocol exposing a simple remote view."""
+
+    view = None
+
+    def initialize(self):
+        self.registerVtkWebProtocol(vtkprotocols.vtkWebMouseHandler())
+        self.registerVtkWebProtocol(vtkprotocols.vtkWebViewPort())
+        self.registerVtkWebProtocol(vtkprotocols.vtkWebViewPortImageDelivery())
+        if PVWServer.view:
+            self.getApplication().GetObjectIdMap().SetActiveObject("VIEW", PVWServer.view)
+        super().initialize()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Launch vtk.js visualizer")
+    parser.add_argument("--data", required=True, help="Mesh file to display")
+    server.add_arguments(parser)
+    args = parser.parse_args()
+
+    PVWServer.view = build_view(args.data)
+    server.start_webserver(options=args, protocol=PVWServer)

--- a/scripts/start_paraview_web.py
+++ b/scripts/start_paraview_web.py
@@ -12,13 +12,12 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 
-from cdb2rad.parser import parse_cdb
-from cdb2rad.vtk_writer import write_vtk
+from cdb2rad.mesh_convert import convert_to_vtk
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Start ParaView Web server")
-    parser.add_argument("cdb_file", help="Input .cdb file")
+    parser.add_argument("mesh_file", help="Input mesh (.cdb/.inp/.rad/.inc)")
     parser.add_argument(
         "--port",
         type=int,
@@ -27,11 +26,9 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    nodes, elements, *_ = parse_cdb(args.cdb_file)
-
     tmp_dir = tempfile.mkdtemp()
     vtk_path = Path(tmp_dir) / "mesh.vtk"
-    write_vtk(nodes, elements, str(vtk_path))
+    convert_to_vtk(args.mesh_file, str(vtk_path))
 
     cmd = [
         "pvpython",

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -12,6 +12,7 @@ if root_path not in sys.path:
     sys.path.insert(0, root_path)
 
 import streamlit as st
+from cdb2rad.mesh_convert import convert_to_vtk
 
 def _rerun():
     """Compatibility wrapper for streamlit rerun."""
@@ -21,10 +22,14 @@ def _rerun():
         st.experimental_rerun()
 
 
-def launch_paraview_server(cdb_path: str, port: int = 12345) -> str:
-    """Spawn ParaView Web server for the given CDB file."""
-    script = Path(__file__).resolve().parents[2] / "scripts" / "start_paraview_web.py"
-    subprocess.Popen(["python", str(script), cdb_path, "--port", str(port)])
+def launch_paraview_server(mesh_path: str, port: int = 12345) -> str:
+    """Spawn ParaViewWeb server for the given mesh file."""
+    script = Path(__file__).resolve().parents[2] / "scripts" / "pv_visualizer.py"
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".vtk")
+    tmp.close()
+    convert_to_vtk(mesh_path, tmp.name)
+    cmd = ["python", str(script), "--data", tmp.name, "--port", str(port)]
+    subprocess.Popen(cmd)
     return f"http://localhost:{port}/"
 
 SDEA_LOGO_URL = (

--- a/src/dashboard/static/vtk_viewer.html
+++ b/src/dashboard/static/vtk_viewer.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      html, body, #render { width: 100%; height: 100%; margin: 0; overflow: hidden; }
+    </style>
+    <script src="https://unpkg.com/vtk.js"></script>
+    <script src="https://unpkg.com/wslink"></script>
+  </head>
+  <body>
+    <div id="render"></div>
+    <script type="text/javascript">
+      const connection = wslink.connect({
+        sessionURL: `ws://${location.hostname}:${location.port}/ws`,
+      });
+      connection.then((session) => {
+        vtk.Rendering.Misc.vtkRemoteView.newInstance({ session }).connect().then((view) => {
+          document.getElementById('render').appendChild(view.getContainer());
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/tests/test_mesh_convert.py
+++ b/tests/test_mesh_convert.py
@@ -1,0 +1,11 @@
+from cdb2rad.mesh_convert import convert_to_vtk
+from pathlib import Path
+
+DATA = Path(__file__).resolve().parents[1] / 'data' / 'model.cdb'
+
+
+def test_convert_to_vtk(tmp_path):
+    out = tmp_path / 'mesh.vtk'
+    convert_to_vtk(str(DATA), str(out))
+    text = out.read_text()
+    assert 'UNSTRUCTURED_GRID' in text


### PR DESCRIPTION
## Summary
- convert mesh formats to VTK for web visualization
- launch a simple wslink server with vtk to display meshes
- embed ParaViewWeb viewer in the dashboard
- document the new workflow in README
- add regression test for mesh conversion

## Testing
- `flake8`
- `mypy cdb2rad/mesh_convert.py` *(fails: module imports missing, type errors)*
- `bandit -r cdb2rad -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d3a01b9a4832789c976dd50747b86