### PR TITLE
Fix session state initialization

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -395,6 +395,9 @@ if file_path:
         value=st.session_state.get("work_dir", str(Path.cwd())),
     )
     st.session_state["work_dir"] = work_dir
+
+    if "parts" not in st.session_state:
+        st.session_state["parts"] = []
     nodes, elements, node_sets, elem_sets, materials = load_cdb(file_path)
     info_tab, preview_tab, inp_tab, rad_tab, help_tab = st.tabs(
         [


### PR DESCRIPTION
## Summary
- prevent `st.session_state` KeyError for "parts" in dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d4ecee1188327870dc3ebde6efc04