### PR TITLE
Add dynamic ParaViewWeb viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,9 @@ La pestaña **Ayuda** ofrece enlaces directos a la documentación principal de R
 Para una visualización más completa de la malla se puede utilizar un servidor
 
 **ParaView Web**. El script ``scripts/pv_visualizer.py`` convierte
-cualquier malla soportada a ``.vtk`` de forma temporal y lanza un
-servidor wslink (host 127.0.0.1 y puerto 12345 por defecto):
+cualquier malla soportada a ``.vtk`` o ``.vtp`` de forma temporal y lanza un
+servidor wslink (host 127.0.0.1 y puerto 12345 por defecto). Ahora también es
+posible generar el fichero VTK en memoria desde la propia aplicación:
 
 ```bash
 python scripts/pv_visualizer.py --data data_files/model.cdb --port 12345 --verbose
@@ -208,8 +209,9 @@ Al ejecutar el comando se mostrará la URL del visualizador. Desde la pestaña
 **Vista 3D** del dashboard se puede iniciar el servidor y el visor quedará
 embebido directamente en la aplicación usando ``static/vtk_viewer.html`` para
 conectarse vía WebSocket y visualizar la malla con todas las herramientas de
-
-ParaView. Si se desea convertir un archivo sin lanzar el servidor puede
+ParaView. La función ``launch_paraview_server`` acepta ahora ``nodes`` y
+``elements`` para exportar el VTK de forma dinámica. Si se desea convertir un
+archivo sin lanzar el servidor puede
 utilizarse ``scripts/convert_to_vtk.py``:
 
 ```bash

--- a/cdb2rad/mesh_convert.py
+++ b/cdb2rad/mesh_convert.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Dict, List, Tuple
+import tempfile
 
 try:  # Optional dependency
     import meshio
@@ -11,7 +13,7 @@ except ImportError:  # pragma: no cover - graceful handling
 
 
 from .parser import parse_cdb
-from .vtk_writer import write_vtk
+from .vtk_writer import write_vtk, write_vtp
 
 
 SUPPORTED_EXT = {".cdb", ".inp", ".rad", ".inc", ".vtk", ".vtp", ".stl", ".obj"}
@@ -36,3 +38,18 @@ def convert_to_vtk(infile: str, outfile: str) -> None:
 
     mesh = meshio.read(infile)
     meshio.write(outfile, mesh)
+
+
+def mesh_to_temp_vtk(
+    nodes: Dict[int, List[float]],
+    elements: List[Tuple[int, int, List[int]]],
+    suffix: str = ".vtk",
+) -> str:
+    """Return path to a temporary VTK/VTP file for *nodes* and *elements*."""
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+    tmp.close()
+    if suffix.endswith(".vtp"):
+        write_vtp(nodes, elements, tmp.name)
+    else:
+        write_vtk(nodes, elements, tmp.name)
+    return tmp.name

--- a/tests/test_vtk_writer.py
+++ b/tests/test_vtk_writer.py
@@ -1,5 +1,5 @@
 from cdb2rad.parser import parse_cdb
-from cdb2rad.vtk_writer import write_vtk
+from cdb2rad.vtk_writer import write_vtk, write_vtp
 import os
 import tempfile
 
@@ -15,4 +15,11 @@ def test_write_vtk():
             content = f.read()
     assert content.startswith('# vtk DataFile')
     assert 'DATASET UNSTRUCTURED_GRID' in content
+
+
+def test_write_vtp(tmp_path):
+    nodes, elements, *_ = parse_cdb(DATA)
+    out = tmp_path / "mesh.vtp"
+    write_vtp(nodes, elements, str(out))
+    assert out.exists() and out.stat().st_size > 0
 


### PR DESCRIPTION
## Summary
- enable exporting `.vtp` meshes via `write_vtp`
- support creating temporary VTK/VTP files from mesh data
- launch ParaView Web server directly from in-memory mesh
- embed ParaView viewer in the dashboard
- document viewer workflow
- test VTP writer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d4e5006f08327ae18699697fab196