### PR TITLE
Add VTK exporter button

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ pestañas principales:
 - **Vista 3D** previsualización ligera de la malla con opción de seleccionar
   los *name selections* que se quieran mostrar.
 
+- **Generar VTK** exporta la malla a ``.vtk`` o ``.vtp`` indicando ruta y nombre.
 -- **Generar INC** permite crear ``mesh.inc`` y muestra sus primeras líneas. \
   Incluye casillas para decidir si exportar las selecciones nombradas y los
   materiales.
@@ -196,8 +197,12 @@ La pestaña **Ayuda** ofrece enlaces directos a la documentación principal de R
 Para una visualización más completa de la malla se puede utilizar un servidor
 
 **ParaView Web**. El script ``scripts/pv_visualizer.py`` convierte
-cualquier malla soportada a ``.vtk`` de forma temporal y lanza un
-servidor wslink (host 127.0.0.1 y puerto 12345 por defecto):
+cualquier malla soportada a ``.vtk`` o ``.vtp`` de forma temporal y lanza un
+servidor wslink (host 127.0.0.1 y puerto 12345 por defecto). Ahora también es
+posible generar el fichero VTK en memoria desde la propia aplicación:
+
+Además, la pestaña permite guardar el archivo con el botón **Generar VTK**,
+especificando la ruta y el nombre deseado.
 
 ```bash
 python scripts/pv_visualizer.py --data data_files/model.cdb --port 12345 --verbose
@@ -208,8 +213,9 @@ Al ejecutar el comando se mostrará la URL del visualizador. Desde la pestaña
 **Vista 3D** del dashboard se puede iniciar el servidor y el visor quedará
 embebido directamente en la aplicación usando ``static/vtk_viewer.html`` para
 conectarse vía WebSocket y visualizar la malla con todas las herramientas de
-
-ParaView. Si se desea convertir un archivo sin lanzar el servidor puede
+ParaView. La función ``launch_paraview_server`` acepta ahora ``nodes`` y
+``elements`` para exportar el VTK de forma dinámica. Si se desea convertir un
+archivo sin lanzar el servidor puede
 utilizarse ``scripts/convert_to_vtk.py``:
 
 ```bash

--- a/cdb2rad/mesh_convert.py
+++ b/cdb2rad/mesh_convert.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Dict, List, Tuple
+import tempfile
 
 try:  # Optional dependency
     import meshio
@@ -11,7 +13,7 @@ except ImportError:  # pragma: no cover - graceful handling
 
 
 from .parser import parse_cdb
-from .vtk_writer import write_vtk
+from .vtk_writer import write_vtk, write_vtp
 
 
 SUPPORTED_EXT = {".cdb", ".inp", ".rad", ".inc", ".vtk", ".vtp", ".stl", ".obj"}
@@ -36,3 +38,18 @@ def convert_to_vtk(infile: str, outfile: str) -> None:
 
     mesh = meshio.read(infile)
     meshio.write(outfile, mesh)
+
+
+def mesh_to_temp_vtk(
+    nodes: Dict[int, List[float]],
+    elements: List[Tuple[int, int, List[int]]],
+    suffix: str = ".vtk",
+) -> str:
+    """Return path to a temporary VTK/VTP file for *nodes* and *elements*."""
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+    tmp.close()
+    if suffix.endswith(".vtp"):
+        write_vtp(nodes, elements, tmp.name)
+    else:
+        write_vtk(nodes, elements, tmp.name)
+    return tmp.name

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -12,7 +12,8 @@ if root_path not in sys.path:
     sys.path.insert(0, root_path)
 
 import streamlit as st
-from cdb2rad.mesh_convert import convert_to_vtk
+from cdb2rad.mesh_convert import convert_to_vtk, mesh_to_temp_vtk
+from cdb2rad.vtk_writer import write_vtk, write_vtp
 
 def _rerun():
     """Compatibility wrapper for streamlit rerun."""
@@ -24,23 +25,33 @@ def _rerun():
 
 
 def launch_paraview_server(
-    mesh_path: str,
+    mesh_path: str | None = None,
+    *,
+    nodes: Dict[int, List[float]] | None = None,
+    elements: List[Tuple[int, int, List[int]]] | None = None,
     port: int = 12345,
     host: str = "127.0.0.1",
     verbose: bool = False,
 ) -> str:
 
-    """Spawn ParaViewWeb server for the given mesh file."""
+    """Spawn ParaViewWeb server for ``mesh_path`` or an in-memory mesh."""
     script = Path(__file__).resolve().parents[2] / "scripts" / "pv_visualizer.py"
-    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".vtk")
-    tmp.close()
-    convert_to_vtk(mesh_path, tmp.name)
+
+    if mesh_path:
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".vtk")
+        tmp.close()
+        convert_to_vtk(mesh_path, tmp.name)
+        data_path = tmp.name
+    elif nodes is not None and elements is not None:
+        data_path = mesh_to_temp_vtk(nodes, elements)
+    else:
+        raise ValueError("mesh_path or nodes/elements must be provided")
 
     cmd = [
         "python",
         str(script),
         "--data",
-        tmp.name,
+        data_path,
         "--port",
         str(port),
         "--host",
@@ -446,9 +457,36 @@ if file_path:
         html = viewer_html(nodes, elements, selected_eids=sel_eids if sel_eids else None)
         st.components.v1.html(html, height=420)
 
+        st.subheader("Exportar VTK")
+        vtk_dir = st.text_input(
+            "Directorio de salida",
+            value=st.session_state.get("work_dir", str(Path.cwd())),
+            key="vtk_dir",
+        )
+        vtk_name = st.text_input("Nombre de archivo", value="mesh", key="vtk_name")
+        vtk_format = st.selectbox("Formato", [".vtk", ".vtp"], key="vtk_format")
+        overwrite_vtk = st.checkbox("Sobrescribir si existe", value=False, key="overwrite_vtk")
+        if st.button("Generar VTK"):
+            out_dir = Path(vtk_dir).expanduser()
+            out_dir.mkdir(parents=True, exist_ok=True)
+            vtk_path = out_dir / f"{vtk_name}{vtk_format}"
+            if vtk_path.exists() and not overwrite_vtk:
+                st.error("El archivo ya existe. Elija otro nombre o active sobrescribir")
+            else:
+                if vtk_format == ".vtp":
+                    write_vtp(nodes, elements, str(vtk_path))
+                else:
+                    write_vtk(nodes, elements, str(vtk_path))
+                st.success(f"Archivo guardado en: {vtk_path}")
+
         port = st.number_input("Puerto ParaView Web", value=12345, step=1)
         if st.button("Visualizar con ParaView Web"):
-            url = launch_paraview_server(file_path, port=int(port), verbose=True)
+            url = launch_paraview_server(
+                nodes=nodes,
+                elements=elements,
+                port=int(port),
+                verbose=True,
+            )
             st.session_state["pvw_url"] = url
         if "pvw_url" in st.session_state:
             st.components.v1.html(

--- a/tests/test_vtk_writer.py
+++ b/tests/test_vtk_writer.py
@@ -1,5 +1,5 @@
 from cdb2rad.parser import parse_cdb
-from cdb2rad.vtk_writer import write_vtk
+from cdb2rad.vtk_writer import write_vtk, write_vtp
 import os
 import tempfile
 
@@ -15,4 +15,11 @@ def test_write_vtk():
             content = f.read()
     assert content.startswith('# vtk DataFile')
     assert 'DATASET UNSTRUCTURED_GRID' in content
+
+
+def test_write_vtp(tmp_path):
+    nodes, elements, *_ = parse_cdb(DATA)
+    out = tmp_path / "mesh.vtp"
+    write_vtp(nodes, elements, str(out))
+    assert out.exists() and out.stat().st_size > 0
 


### PR DESCRIPTION
## Summary
- allow users to save the mesh as VTK/VTP from the dashboard
- document the new **Generar VTK** option in README

## Testing
- `pytest -q`
- `flake8` *(fails: E501, E402, etc. but allowed)*
- `mypy --ignore-missing-imports cdb2rad` *(fails: 38 errors)*
- `bandit -r cdb2rad`

------
https://chatgpt.com/codex/tasks/task_e_685d4e5006f08327ae18699697fab196