### PR TITLE
Simplify ParaView tab and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Para una visualización más completa de la malla se puede utilizar un servidor
 
 **ParaView Web**. El script ``scripts/pv_visualizer.py`` convierte
 cualquier malla soportada a ``.vtk`` o ``.vtp`` de forma temporal y lanza un
-servidor wslink (host 127.0.0.1 y puerto 12345 por defecto). Ahora también es
+servidor wslink (host 127.0.0.1 y puerto 8080 por defecto). Ahora también es
 posible generar el fichero VTK en memoria desde la propia aplicación:
 
 
@@ -208,7 +208,7 @@ especificando la ruta y el nombre deseado.
 
 
 ```bash
-python scripts/pv_visualizer.py --data data_files/model.cdb --port 12345 --verbose
+python scripts/pv_visualizer.py --data data_files/model.cdb --port 8080 --verbose
 
 ```
 

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -454,19 +454,13 @@ if file_path:
             st.write(f"- ID {mid}: {props}")
 
     with preview_tab:
-        st.write("Selecciona conjuntos de elementos para visualizar:")
-        all_elem_sets = {**elem_sets, **st.session_state.get("subsets", {})}
-        selected_sets = st.multiselect(
-            "Conjuntos", list(all_elem_sets.keys()), default=list(all_elem_sets.keys())
+        port = st.number_input("Puerto ParaView Web", value=8080, step=1)
+        cmd = (
+            f"\"C:\\Program Files\\ParaView 5.12.0\\bin\\pvpython.exe\" "
+            f"-m paraview.apps.visualizer --data \"C:\\JAVIER\\OPEN_RADIOSS\\paraview\\data\" "
+            f"--content \"C:\\JAVIER\\OPEN_RADIOSS\\paraview\\www\" --port {int(port)}"
         )
-        sel_eids = set()
-        for name in selected_sets:
-            sel_eids.update(all_elem_sets.get(name, []))
-
-        html = viewer_html(nodes, elements, selected_eids=sel_eids if sel_eids else None)
-        st.components.v1.html(html, height=420)
-
-        port = st.number_input("Puerto ParaView Web", value=12345, step=1)
+        st.text_input("Comando para lanzar", value=cmd, key="pv_cmd")
         if st.button("Visualizar con ParaView Web"):
             url = launch_paraview_server(
                 nodes=nodes,


### PR DESCRIPTION
## Summary
- default ParaView Web port 8080
- show command string and remove set selector
- update docs to mention port 8080

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d9461440c8327b70399eb292591c4