### PR TITLE
Fix session state initialization for subsets

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -412,6 +412,8 @@ if file_path:
 
     if "parts" not in st.session_state:
         st.session_state["parts"] = []
+    if "subsets" not in st.session_state:
+        st.session_state["subsets"] = {}
     nodes, elements, node_sets, elem_sets, materials = load_cdb(file_path)
 
     info_tab, preview_tab, vtk_tab, inp_tab, rad_tab, help_tab = st.tabs(


### PR DESCRIPTION
## Summary
- initialize `subsets` in Streamlit app to avoid KeyError

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d94c113f883279144697f95f1f680