### PR TITLE
Integrate VTK tools into 3D view

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ el número y tipo de elementos y generar los ficheros ``mesh.inc`` y
 streamlit run src/dashboard/app.py
 ```
 
-Se puede subir un archivo ``.cdb`` propio. La interfaz cuenta con cuatro
+Se puede subir un archivo ``.cdb`` propio. La interfaz cuenta con varias
 pestañas principales:
 
 - En la parte superior se puede elegir el **sistema de unidades** (``SI`` o
@@ -158,9 +158,10 @@ pestañas principales:
 
 - **Información** resumen de nodos y elementos.
 - **Vista 3D** previsualización ligera de la malla con opción de seleccionar
-  los *name selections* que se quieran mostrar.
-
-- **Generar VTK** exporta la malla a ``.vtk`` o ``.vtp`` indicando ruta y nombre.
+  los *name selections* que se quieran mostrar. Desde esta pestaña también es
+  posible **exportar VTK** indicando directorio y formato.
+- **Propiedades** permite definir propiedades y partes que luego se incluirán en
+  el ``starter``.
 - **Generar INC** permite crear ``mesh.inc`` y muestra sus primeras líneas. \
 
   Incluye casillas para decidir si exportar las selecciones nombradas y los
@@ -203,8 +204,8 @@ servidor wslink (host 127.0.0.1 y puerto 8080 por defecto). Ahora también es
 posible generar el fichero VTK en memoria desde la propia aplicación:
 
 
-Además, la pestaña permite guardar el archivo con el botón **Generar VTK**,
-especificando la ruta y el nombre deseado.
+Además, desde la pestaña *Vista 3D* se puede guardar el archivo con el botón
+**Generar VTK**, especificando la ruta y el nombre deseado.
 
 
 ```bash

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -420,12 +420,11 @@ if file_path:
         st.session_state["subsets"] = {}
     nodes, elements, node_sets, elem_sets, materials = load_cdb(file_path)
 
-    info_tab, preview_tab, vtk_tab, settings_tab, inp_tab, rad_tab, help_tab = st.tabs(
+    info_tab, preview_tab, prop_tab, inp_tab, rad_tab, help_tab = st.tabs(
         [
             "Información",
             "Vista 3D",
-            "Generar VTK",
-            "Settings",
+            "Propiedades",
             "Generar INC",
             "Generar RAD",
             "Ayuda",
@@ -482,7 +481,6 @@ if file_path:
                 height=620,
             )
 
-    with vtk_tab:
         st.subheader("Exportar VTK")
         vtk_dir = st.text_input(
             "Directorio de salida",
@@ -506,7 +504,7 @@ if file_path:
                 st.success(f"Archivo guardado en: {vtk_path}")
 
 
-    with settings_tab:
+    with prop_tab:
         st.subheader("Configuración de propiedades")
         if "properties" not in st.session_state:
             st.session_state["properties"] = []


### PR DESCRIPTION
## Summary
- integrate VTK export section inside the 3D viewer
- rename **Settings** tab to **Propiedades**
- document new tab layout and VTK export in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685da0a45fac8327bc51052432c031a2