### PR TITLE
Add property section into RAD generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,12 @@ pestañas principales:
 - **Vista 3D** previsualización ligera de la malla con opción de seleccionar
   los *name selections* que se quieran mostrar.
 
--- **Generar INC** permite crear ``mesh.inc`` y muestra sus primeras líneas. \
+
+- **Generar INC** permite crear ``mesh.inc`` y muestra sus primeras líneas. \
   Incluye casillas para decidir si exportar las selecciones nombradas y los
   materiales.
 
-- **Generar RAD** para introducir parámetros de cálculo y obtener
+- **Generar RAD** para introducir parámetros de cálculo, definir **Propiedades** y obtener
   ``model_0000.rad``.
 Se incluyen casillas opcionales para **sobrescribir** los archivos
 ``.inc`` o ``.rad`` si ya existen en el directorio de salida.

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -57,6 +57,7 @@ from cdb2rad.writer_rad import (
     DEFAULT_STOP_NTH,
     DEFAULT_STOP_NANIM,
     DEFAULT_STOP_NERR,
+    DEFAULT_THICKNESS,
 )
 from cdb2rad.writer_inc import write_mesh_inc
 from cdb2rad.rad_validator import validate_rad_format
@@ -430,7 +431,6 @@ if file_path:
                 height=620,
             )
 
-
     with inp_tab:
         st.subheader("Generar mesh.inc")
 
@@ -497,6 +497,74 @@ if file_path:
             st.session_state["rbe3"] = []
         if "remote_points" not in st.session_state:
             st.session_state["remote_points"] = []
+        if "properties" not in st.session_state:
+            st.session_state["properties"] = []
+        if "parts" not in st.session_state:
+            st.session_state["parts"] = []
+        if "subsets" not in st.session_state:
+            st.session_state["subsets"] = {}
+
+        with st.expander("Propiedades"):
+            st.subheader("Configuración de propiedades")
+            with st.expander("Definir propiedad"):
+                pid = st.number_input(
+                    "ID propiedad",
+                    value=len(st.session_state["properties"]) + 1,
+                    key="prop_id",
+                )
+                pname = st.text_input("Nombre", value=f"PROP_{pid}", key="prop_name")
+                ptype = st.selectbox("Tipo", ["SHELL", "SOLID"], key="prop_type")
+                if ptype == "SHELL":
+                    thick = st.number_input("Espesor", value=DEFAULT_THICKNESS, key="prop_thick")
+                else:
+                    thick = None
+                if st.button("Añadir propiedad"):
+                    data = {"id": int(pid), "name": pname, "type": ptype}
+                    if thick is not None:
+                        data["thickness"] = thick
+                    st.session_state["properties"].append(data)
+
+            if st.session_state["properties"]:
+                st.write("Propiedades definidas:")
+                for i, pr in enumerate(st.session_state["properties"]):
+                    cols = st.columns([4, 1])
+                    with cols[0]:
+                        st.json(pr)
+                    with cols[1]:
+                        if st.button("Eliminar", key=f"del_prop_{i}"):
+                            st.session_state["properties"].pop(i)
+                            _rerun()
+
+            with st.expander("Definir parte"):
+                part_id = st.number_input(
+                    "ID parte",
+                    value=len(st.session_state["parts"]) + 1,
+                    key="part_id",
+                )
+                part_name = st.text_input("Nombre parte", value=f"PART_{part_id}", key="part_name")
+                prop_opts = [p["id"] for p in st.session_state["properties"]]
+                pid_sel = st.selectbox("Propiedad", prop_opts, disabled=not prop_opts, key="part_pid")
+                mid_sel = st.number_input("Material ID", value=1, key="part_mid")
+                if st.button("Añadir parte"):
+                    st.session_state["parts"].append(
+                        {
+                            "id": int(part_id),
+                            "name": part_name,
+                            "pid": int(pid_sel) if prop_opts else 1,
+                            "mid": int(mid_sel),
+                        }
+                    )
+
+            if st.session_state["parts"]:
+                st.write("Partes definidas:")
+                for i, pt in enumerate(st.session_state["parts"]):
+                    cols = st.columns([4, 1])
+                    with cols[0]:
+                        st.json(pt)
+                    with cols[1]:
+                        if st.button("Eliminar", key=f"del_part_{i}"):
+                            st.session_state["parts"].pop(i)
+                            _rerun()
 
         extra_nodes = {
             rp["id"]: list(rp["coords"])
@@ -1048,6 +1116,8 @@ if file_path:
                         rbe3=st.session_state.get("rbe3"),
                         init_velocity=st.session_state.get("init_vel"),
                         gravity=st.session_state.get("gravity"),
+                        properties=st.session_state.get("properties"),
+                        parts=st.session_state.get("parts"),
                     )
                 try:
                     validate_rad_format(str(rad_path))

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -285,3 +285,18 @@ def test_write_rad_with_connectors(tmp_path):
     assert '/RBE3/1' in text
 
 
+def test_write_rad_with_properties(tmp_path):
+    nodes, elements, *_ = parse_cdb(DATA)
+    rad = tmp_path / 'prop.rad'
+    props = [
+        {'id': 1, 'name': 'shell_prop', 'type': 'SHELL', 'thickness': 1.2}
+    ]
+    parts = [
+        {'id': 1, 'name': 'part1', 'pid': 1, 'mid': 1}
+    ]
+    write_rad(nodes, elements, str(rad), properties=props, parts=parts)
+    txt = rad.read_text()
+    assert '/PROP/SHELL/1' in txt
+    assert '/PART/1' in txt
+
+


### PR DESCRIPTION
## Summary
- move property and part configuration under "Propiedades" expander inside *Generar RAD*
- remove separate Settings tab and update README
- guard missing `st.session_state['subsets']`

## Testing
- `flake8` *(fails: many style errors)*
- `mypy cdb2rad` *(fails: 37 errors)*
- `bandit -r cdb2rad -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d4d2e2b4c8327ba215b2fe8b2ce7c