### PR TITLE
Add default VTK export path

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ pestañas principales:
 - **Información** resumen de nodos y elementos.
 - **Vista 3D** previsualización ligera de la malla con opción de seleccionar
   los *name selections* que se quieran mostrar. Desde esta pestaña también es
-  posible **exportar VTK** indicando directorio y formato.
+  posible **exportar VTK** indicando directorio y formato. Por defecto se sugiere
+  `C:\JAVIER\OPEN_RADIOSS\paraview\data` como directorio de salida.
 - **Propiedades** permite definir propiedades y partes que luego se incluirán en
   el ``starter``.
 - **Generar INC** permite crear ``mesh.inc`` y muestra sus primeras líneas. \

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -74,6 +74,9 @@ OPENRADIOSS_LOGO_URL = (
 )
 ANSYS_LOGO_URL = "https://www.ansys.com/content/dam/company/brand/logos/ansys-logos/ansys-logo.svg"
 
+# Default output directory for exported VTK files
+DEFAULT_VTK_DIR = r"C:\JAVIER\OPEN_RADIOSS\paraview\data"
+
 from cdb2rad.parser import parse_cdb
 from cdb2rad.writer_rad import (
     write_rad,
@@ -489,7 +492,7 @@ if file_path:
         st.subheader("Exportar VTK")
         vtk_dir = st.text_input(
             "Directorio de salida",
-            value=st.session_state.get("work_dir", str(Path.cwd())),
+            value=st.session_state.get("vtk_dir", DEFAULT_VTK_DIR),
             key="vtk_dir",
         )
         vtk_name = st.text_input("Nombre de archivo", value="mesh", key="vtk_name")


### PR DESCRIPTION
## Summary
- default VTK export path is now C:\JAVIER\OPEN_RADIOSS\paraview\data
- document the default path in the README

## Testing
- `pytest -q`
- `flake8`
- `mypy .`
- `bandit -r cdb2rad`


------
https://chatgpt.com/codex/tasks/task_e_685daafeeab48327b8f65f93f1e5471f