### PR TITLE
Add options for minimal RAD generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ opción ``--skip-include`` se genera el ``.rad`` sin esa referencia:
 python scripts/run_all.py data_files/model.cdb --rad model.rad --skip-include
 ```
 
+Para generar un ``.rad`` limpio sin tarjetas de control ni material por defecto
+pueden emplearse las opciones ``--no-run-cards`` y ``--no-default-material``:
+
+```bash
+python scripts/run_all.py data_files/model.cdb --rad vacio.rad --no-run-cards --no-default-material
+```
+
 ### Entorno virtual y OpenRadioss
 
 Para crear un entorno virtual con `pytest` y descargar la última

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -25,6 +25,16 @@ def main() -> None:
         action="store_true",
         help="Do not include the mesh.inc file inside the generated .rad",
     )
+    parser.add_argument(
+        "--no-run-cards",
+        action="store_true",
+        help="Omit /RUN and related control cards from the .rad file",
+    )
+    parser.add_argument(
+        "--no-default-material",
+        action="store_true",
+        help="Do not insert a default material when none are provided",
+    )
 
     args = parser.parse_args()
 
@@ -51,6 +61,8 @@ def main() -> None:
             args.rad,
             mesh_inc=args.inc or "mesh.inc",
             include_inc=not args.skip_include,
+            include_run=not args.no_run_cards,
+            default_material=not args.no_default_material,
             node_sets=node_sets,
             elem_sets=elem_sets,
             materials=materials,


### PR DESCRIPTION
## Summary
- allow `write_rad` to skip control cards and default material
- expose new `--no-run-cards` and `--no-default-material` flags in `run_all.py`
- document the new CLI options in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685db359f07c8327a5a2a4489883d166