### PR TITLE
Add Johnson-Cook failure defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,23 @@ Radioss. Para depurar y ampliar estos ficheros se recomienda consultar el
 En ella se explica el formato, las palabras clave disponibles y la estructura
 del ``starter`` y los ficheros ``engine``.
 
+## Criterios de fallo
+
+El dashboard permite añadir tarjetas ``/FAIL`` para distintos modelos.
+Para el criterio de daño **Johnson-Cook** se suelen emplear los siguientes
+coeficientes de referencia:
+
+```text
+D1 = -0.77
+D2 = 1.45
+D3 = -0.47
+D4 = 0.0
+D5 = 1.6
+```
+
+Si en el material solo se indica ``"FAIL": {"TYPE": "JOHNSON"}``, estos valores
+se completarán automáticamente.
+
 ## Ejemplo de uso
 
 ```bash

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -300,3 +300,12 @@ def test_write_rad_with_properties(tmp_path):
     assert '/PART/1' in txt
 
 
+def test_apply_default_failure():
+    mats = {1: {"LAW": "LAW2", "FAIL": {"TYPE": "JOHNSON"}}}
+    result = apply_default_materials(mats)
+    fail = result[1]["FAIL"]
+    assert fail["TYPE"] == "JOHNSON"
+    assert fail["D1"] == -0.77
+    assert fail["D5"] == 1.6
+
+


### PR DESCRIPTION
## Summary
- provide Johnson-Cook failure parameters as defaults
- fill defaults inside `apply_default_materials`
- document typical failure values in README
- test automatic completion

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685db462e9a88327b7125b0b56ad5ad4