### PR TITLE
Add options for minimal RAD generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ opción ``--skip-include`` se genera el ``.rad`` sin esa referencia:
 python scripts/run_all.py data_files/model.cdb --rad model.rad --skip-include
 ```
 
+Por defecto ``model_0000.rad`` no incluye tarjetas de control ``/RUN`` ni un
+material inicial. Estas se pueden añadir con las opciones ``--run-cards`` y
+``--default-material``:
+
+```bash
+python scripts/run_all.py data_files/model.cdb --rad completo.rad --run-cards --default-material
+```
+
 ### Entorno virtual y OpenRadioss
 
 Para crear un entorno virtual con `pytest` y descargar la última

--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -77,6 +77,8 @@ def write_rad(
     gravity: Dict[str, float] | None = None,
     properties: List[Dict[str, Any]] | None = None,
     parts: List[Dict[str, Any]] | None = None,
+    include_run: bool = False,
+    default_material: bool = False,
 ) -> None:
     """Generate ``model_0000.rad`` with optional solver controls.
 
@@ -86,7 +88,10 @@ def write_rad(
     ``print_n`` or ``print_line`` to omit the corresponding block in
     the generated file. Gravity loading can be specified via the
     ``gravity`` parameter. Set ``include_inc`` to ``False`` to omit the
-    ``#include`` line referencing the mesh.
+    ``#include`` line referencing the mesh. Set ``include_run=True`` to
+    write control cards like ``/RUN`` and ``/STOP``. Set ``default_material``
+    to ``True`` to insert a placeholder material when none are
+    provided.
     """
 
     all_mats: Dict[int, Dict[str, float]] = {}
@@ -152,39 +157,40 @@ def write_rad(
         f.write("                  kg                  mm                   s\n")
         f.write("                  kg                  mm                   s\n")
 
-        # General printout frequency
-        if print_n is not None and print_line is not None:
-            f.write(f"/PRINT/{print_n}/{print_line}\n")
-        f.write(f"/RUN/{runname}/1/\n")
-        f.write(f"                {t_end}\n")
-        f.write("/STOP\n")
-        f.write(
-            f"{stop_emax} {stop_mmax} {stop_nmax} {stop_nth} {stop_nanim} {stop_nerr}\n"
-        )
-        if tfile_dt is not None:
-            f.write("/TFILE/0\n")
-            f.write(f"{tfile_dt}\n")
-        f.write("/VERS/2024\n")
-        if dt_ratio is not None:
-            f.write("/DT/NODA/CST/0\n")
-            f.write(f"{dt_ratio} 0 0\n")
-        if anim_dt is not None:
-            f.write("/ANIM/DT\n")
-            f.write(f"0 {anim_dt}\n")
-        if h3d_dt is not None:
-            f.write("/H3D/DT\n")
-            f.write(f"0 {h3d_dt}\n")
-        if rfile_cycle is not None:
-            if rfile_n is not None:
-                f.write(f"/RFILE/{rfile_n}\n")
-            else:
-                f.write("/RFILE\n")
-            f.write(f"{rfile_cycle}\n")
-        if adyrel is not None and (adyrel[0] is not None or adyrel[1] is not None):
-            f.write("/ADYREL\n")
-            tstart = 0.0 if adyrel[0] is None else adyrel[0]
-            tstop = t_end if adyrel[1] is None else adyrel[1]
-            f.write(f"{tstart} {tstop}\n")
+        if include_run:
+            # General printout frequency
+            if print_n is not None and print_line is not None:
+                f.write(f"/PRINT/{print_n}/{print_line}\n")
+            f.write(f"/RUN/{runname}/1/\n")
+            f.write(f"                {t_end}\n")
+            f.write("/STOP\n")
+            f.write(
+                f"{stop_emax} {stop_mmax} {stop_nmax} {stop_nth} {stop_nanim} {stop_nerr}\n"
+            )
+            if tfile_dt is not None:
+                f.write("/TFILE/0\n")
+                f.write(f"{tfile_dt}\n")
+            f.write("/VERS/2024\n")
+            if dt_ratio is not None:
+                f.write("/DT/NODA/CST/0\n")
+                f.write(f"{dt_ratio} 0 0\n")
+            if anim_dt is not None:
+                f.write("/ANIM/DT\n")
+                f.write(f"0 {anim_dt}\n")
+            if h3d_dt is not None:
+                f.write("/H3D/DT\n")
+                f.write(f"0 {h3d_dt}\n")
+            if rfile_cycle is not None:
+                if rfile_n is not None:
+                    f.write(f"/RFILE/{rfile_n}\n")
+                else:
+                    f.write("/RFILE\n")
+                f.write(f"{rfile_cycle}\n")
+            if adyrel is not None and (adyrel[0] is not None or adyrel[1] is not None):
+                f.write("/ADYREL\n")
+                tstart = 0.0 if adyrel[0] is None else adyrel[0]
+                tstop = t_end if adyrel[1] is None else adyrel[1]
+                f.write(f"{tstart} {tstop}\n")
 
         # 2. MATERIALS
         def write_law1(mid: int, name: str, rho: float, e: float, nu: float) -> None:
@@ -245,7 +251,8 @@ def write_rad(
             f.write(f"{a} {b} {n_val} {c_val}\n")
 
         if not all_mats:
-            write_law1(1, "Default_Mat", density, young, poisson)
+            if default_material:
+                write_law1(1, "Default_Mat", density, young, poisson)
         else:
             for mid, props in all_mats.items():
                 law = props.get("LAW", "LAW1").upper()

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -25,6 +25,16 @@ def main() -> None:
         action="store_true",
         help="Do not include the mesh.inc file inside the generated .rad",
     )
+    parser.add_argument(
+        "--run-cards",
+        action="store_true",
+        help="Include /RUN and related control cards in the .rad file",
+    )
+    parser.add_argument(
+        "--default-material",
+        action="store_true",
+        help="Insert a default material when none are provided",
+    )
 
     args = parser.parse_args()
 
@@ -51,6 +61,8 @@ def main() -> None:
             args.rad,
             mesh_inc=args.inc or "mesh.inc",
             include_inc=not args.skip_include,
+            include_run=args.run_cards,
+            default_material=args.default_material,
             node_sets=node_sets,
             elem_sets=elem_sets,
             materials=materials,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -63,6 +63,7 @@ def test_write_rad(tmp_path):
         anim_dt=0.002,
         tfile_dt=0.0001,
         dt_ratio=0.8,
+        include_run=True,
 
     )
     content = rad.read_text()
@@ -217,6 +218,7 @@ def test_write_rad_advanced_options(tmp_path):
         stop_nanim=1,
         stop_nerr=0,
         adyrel=(0.0, 0.02),
+        include_run=True,
     )
     text = rad.read_text()
     assert '/RFILE/2' in text


### PR DESCRIPTION
## Summary
- allow `write_rad` to skip control cards and default material
- expose new `--run-cards` and `--default-material` flags in `run_all.py`
- document the new CLI options in README
- adjust tests for updated defaults

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685db359f07c8327a5a2a4489883d166