### PR TITLE
Add subset support in starter writer

### DIFF
--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -77,6 +77,7 @@ def write_rad(
     gravity: Dict[str, float] | None = None,
     properties: List[Dict[str, Any]] | None = None,
     parts: List[Dict[str, Any]] | None = None,
+    subsets: Dict[str, List[int]] | None = None,
     include_run: bool = True,
     default_material: bool = True,
 ) -> None:
@@ -485,6 +486,19 @@ def write_rad(
                     f.write(f"/PROP/{ptype}/{pid}\n")
                     f.write(f"{pname}\n")
                     f.write("# property parameters not defined\n")
+
+        if subsets:
+            for idx, (name, ids) in enumerate(subsets.items(), start=1):
+                f.write(f"/SUBSET/{idx}\n")
+                f.write(f"{name}\n")
+                line: List[str] = []
+                for i, sid in enumerate(ids, 1):
+                    line.append(str(sid))
+                    if i % 10 == 0:
+                        f.write(" ".join(line) + "\n")
+                        line = []
+                if line:
+                    f.write(" ".join(line) + "\n")
 
         if init_velocity:
             nodes_v = init_velocity.get("nodes", [])

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1254,6 +1254,7 @@ if file_path:
                         gravity=st.session_state.get("gravity"),
                         properties=st.session_state.get("properties"),
                         parts=st.session_state.get("parts"),
+                        subsets=st.session_state.get("subsets"),
                     )
                 try:
                     validate_rad_format(str(rad_path))

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -300,3 +300,13 @@ def test_write_rad_with_properties(tmp_path):
     assert '/PART/1' in txt
 
 
+def test_write_rad_with_subset(tmp_path):
+    nodes, elements, *_ = parse_cdb(DATA)
+    rad = tmp_path / 'subset.rad'
+    subs = {'grp1': [1, 2, 3]}
+    write_rad(nodes, elements, str(rad), subsets=subs)
+    txt = rad.read_text()
+    assert '/SUBSET/1' in txt
+    assert 'grp1' in txt
+
+


### PR DESCRIPTION
## Summary
- support SUBSET definitions when writing `.rad` files
- expose new subset option from the dashboard
- test subset card generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc0afaf688327a1b8eb5b1871a82f