### PR TITLE
Add SUBSET validation

### DIFF
--- a/cdb2rad/rad_validator.py
+++ b/cdb2rad/rad_validator.py
@@ -52,6 +52,7 @@ KEYWORDS = (
     "/RBE3/",
     "/TH/",
     "/FUNCT/",
+    "/SUBSET/",
 )
 
 
@@ -83,6 +84,27 @@ def _validate_grnod(lines: list[str], idx: int) -> int:
             break
         if not t.isdigit():
             raise ValueError(f"Invalid node id: {t}")
+        i += 1
+    return i - 1
+
+
+def _validate_subset(lines: list[str], idx: int) -> int:
+    """Validate a ``/SUBSET`` block starting at ``idx``."""
+    if idx + 1 >= len(lines):
+        raise ValueError("Incomplete /SUBSET block")
+    if not lines[idx + 1].strip():
+        raise ValueError("Missing subset name")
+    i = idx + 2
+    while i < len(lines):
+        t = lines[i].strip()
+        if not t or t.startswith("#"):
+            i += 1
+            continue
+        if t.startswith("/"):
+            break
+        for tok in t.split():
+            if not tok.isdigit():
+                raise ValueError(f"Invalid subset id: {tok}")
         i += 1
     return i - 1
 
@@ -169,6 +191,11 @@ def validate_rad_format(filepath: str) -> None:
             if i + 5 >= len(lines):
                 raise ValueError("Incomplete /RBE3 block")
             i += 6
+            continue
+
+        if line.startswith("/SUBSET/"):
+            i = _validate_subset(lines, i)
+            i += 1
             continue
 
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -43,3 +43,9 @@ def test_invalid_keyword(tmp_path):
     bad.write_text("/UNKNOWN\n1 2 3\n")
     with pytest.raises(ValueError):
         validate_rad_format(str(bad))
+
+
+def test_validate_subset(tmp_path):
+    rad = tmp_path / "subset.rad"
+    rad.write_text("/SUBSET/1\nset1\n1 2 3\n/END\n")
+    validate_rad_format(str(rad))


### PR DESCRIPTION
## Summary
- handle `/SUBSET` blocks in `rad_validator`
- test validator with subset blocks

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc649038083279df99c8df5e24877