### PR TITLE
Add SUBSET validation

### DIFF
--- a/cdb2rad/rad_validator.py
+++ b/cdb2rad/rad_validator.py
@@ -52,6 +52,7 @@ KEYWORDS = (
     "/RBE3/",
     "/TH/",
     "/FUNCT/",
+    "/SUBSET/",
 )
 
 
@@ -83,6 +84,27 @@ def _validate_grnod(lines: list[str], idx: int) -> int:
             break
         if not t.isdigit():
             raise ValueError(f"Invalid node id: {t}")
+        i += 1
+    return i - 1
+
+
+def _validate_subset(lines: list[str], idx: int) -> int:
+    """Validate a ``/SUBSET`` block starting at ``idx``."""
+    if idx + 1 >= len(lines):
+        raise ValueError("Incomplete /SUBSET block")
+    if not lines[idx + 1].strip():
+        raise ValueError("Missing subset name")
+    i = idx + 2
+    while i < len(lines):
+        t = lines[i].strip()
+        if not t or t.startswith("#"):
+            i += 1
+            continue
+        if t.startswith("/"):
+            break
+        for tok in t.split():
+            if not tok.isdigit():
+                raise ValueError(f"Invalid subset id: {tok}")
         i += 1
     return i - 1
 
@@ -169,6 +191,11 @@ def validate_rad_format(filepath: str) -> None:
             if i + 5 >= len(lines):
                 raise ValueError("Incomplete /RBE3 block")
             i += 6
+            continue
+
+        if line.startswith("/SUBSET/"):
+            i = _validate_subset(lines, i)
+            i += 1
             continue
 
 

--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -498,6 +498,27 @@ def write_rad(
                     f.write(f"                   {hm}                   {hf}                {hr}                   {dm}                   {dn}\n")
                     f.write("#        N   Istrain               Thick           Ashear              Ithick     Iplas\n")
                     f.write(f"         {n}         {istr}                 {thick}                   {ashear}                   {ithick}         {ip}\n")
+                elif ptype == "SOLID":
+                    isol = int(prop.get("Isolid", 24))
+                    ismstr = int(prop.get("Ismstr", 4))
+                    icpre = int(prop.get("Icpre", 1))
+                    iframe = int(prop.get("Iframe", 1))
+                    inpts = int(prop.get("Inpts", 222))
+                    qa = float(prop.get("qa", 1.1))
+                    qb = float(prop.get("qb", 0.05))
+                    dn = float(prop.get("dn", 0.1))
+                    h = float(prop.get("h", 0.0))
+
+                    f.write(f"/PROP/SOLID/{pid}\n")
+                    f.write(f"{pname}\n")
+                    f.write("#  Isolid   Ismstr    Icpre   Iframe\n")
+                    f.write(
+                        f"       {isol}        {ismstr}        {icpre}        {iframe}\n"
+                    )
+                    f.write("#  Inpts       qa        qb        dn         h\n")
+                    f.write(
+                        f"   {inpts:5d}   {qa:<8g}   {qb:<8g}   {dn:<8g}   {h:<8g}\n"
+                    )
                 else:
                     f.write(f"/PROP/{ptype}/{pid}\n")
                     f.write(f"{pname}\n")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -334,4 +334,30 @@ def test_write_rad_with_advanced_shell(tmp_path):
     assert nums3[2] == '1.2'
 
 
+def test_write_rad_with_solid_prop(tmp_path):
+    nodes, elements, *_ = parse_cdb(DATA)
+    rad = tmp_path / 'solid.rad'
+    props = [
+        {
+            'id': 1,
+            'name': 'solid_p',
+            'type': 'SOLID',
+            'Isolid': 24,
+            'Ismstr': 4,
+        }
+    ]
+    parts = [{
+        'id': 1,
+        'name': 'part1',
+        'pid': 1,
+        'mid': 1,
+    }]
+    write_rad(nodes, elements, str(rad), properties=props, parts=parts)
+    lines = rad.read_text().splitlines()
+    idx = lines.index('/PROP/SOLID/1')
+    assert 'Isolid' in lines[idx + 2]
+    nums = lines[idx + 3].split()
+    assert nums[0] == '24'
+
+
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -43,3 +43,9 @@ def test_invalid_keyword(tmp_path):
     bad.write_text("/UNKNOWN\n1 2 3\n")
     with pytest.raises(ValueError):
         validate_rad_format(str(bad))
+
+
+def test_validate_subset(tmp_path):
+    rad = tmp_path / "subset.rad"
+    rad.write_text("/SUBSET/1\nset1\n1 2 3\n/END\n")
+    validate_rad_format(str(rad))


### PR DESCRIPTION
## Summary
- handle `/SUBSET` blocks in `rad_validator`
- test validator with subset blocks
- add support for SOLID properties in `writer_rad`
- test solid property generation

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc649038083279df99c8df5e24877