### PR TITLE
Add Johnson failure defaults

### DIFF
--- a/cdb2rad/material_defaults.py
+++ b/cdb2rad/material_defaults.py
@@ -45,6 +45,12 @@ DEFAULT_STEEL_MATERIALS: Dict[str, Dict[str, float]] = {
     },
 }
 
+# Default failure parameters for common criteria
+DEFAULT_FAIL_PARAMS: Dict[str, Dict[str, float]] = {
+    "JOHNSON": {"D1": -0.09, "D2": 0.25, "D3": -0.5, "D4": 0.014, "D5": 1.12},
+    "BIQUAD": {"ALPHA": 0.0, "BETA": 0.0, "M": 0.0, "N": 0.0},
+}
+
 
 def apply_default_materials(materials: Dict[int, Dict[str, float]]) -> Dict[int, Dict[str, float]]:
     """Fill missing properties using :data:`DEFAULT_STEEL_MATERIALS`."""
@@ -58,6 +64,14 @@ def apply_default_materials(materials: Dict[int, Dict[str, float]]) -> Dict[int,
                 # defer to global parameters if provided in writers
                 continue
             merged.setdefault(key, val)
+        if "FAIL" in merged:
+            fail = merged["FAIL"]
+            ftype = str(fail.get("TYPE", "")).upper()
+            f_defaults = DEFAULT_FAIL_PARAMS.get(ftype)
+            if f_defaults:
+                for k, v in f_defaults.items():
+                    fail.setdefault(k, v)
+            fail["TYPE"] = ftype
         merged["LAW"] = law
         result[mid] = merged
     return result

--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -317,7 +317,17 @@ def write_rad(
                 if "FAIL" in props:
                     fail = props["FAIL"]
                     ftype = str(fail.get("TYPE", "")).upper()
-                    if ftype == "BIQUAD":
+                    fname = fail.get("NAME", f"FAIL_{mid}")
+                    if ftype == "JOHNSON":
+                        d1 = fail.get("D1", -0.09)
+                        d2 = fail.get("D2", 0.25)
+                        d3 = fail.get("D3", -0.5)
+                        d4 = fail.get("D4", 0.014)
+                        d5 = fail.get("D5", 1.12)
+                        f.write(f"/FAIL/JOHNSON/{mid}\n")
+                        f.write(f"{fname}\n")
+                        f.write(f"{d1} {d2} {d3} {d4} {d5}\n")
+                    elif ftype == "BIQUAD":
                         alpha = fail.get("ALPHA", 0.0)
                         beta = fail.get("BETA", 0.0)
                         m = fail.get("M", 0.0)
@@ -327,7 +337,8 @@ def write_rad(
                         f.write(f"  {alpha}   {beta}   {m}   {n_fail}\n")
                     elif ftype:
                         f.write(f"/FAIL/{ftype}/{mid}\n")
-                        vals = [str(v) for k, v in fail.items() if k != "TYPE"]
+                        f.write(f"{fname}\n")
+                        vals = [str(v) for k, v in fail.items() if k not in {"TYPE", "NAME"}]
                         if vals:
                             f.write(" ".join(vals) + "\n")
 

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -667,11 +667,11 @@ if file_path:
                     fail_params: Dict[str, float] = {}
                     if fail_type:
                         if fail_type == "JOHNSON":
-                            fail_params["D1"] = input_with_help("D1", 0.0, "d1")
-                            fail_params["D2"] = input_with_help("D2", 0.0, "d2")
-                            fail_params["D3"] = input_with_help("D3", 0.0, "d3")
-                            fail_params["D4"] = input_with_help("D4", 0.0, "d4")
-                            fail_params["D5"] = input_with_help("D5", 0.0, "d5")
+                            fail_params["D1"] = input_with_help("D1", -0.09, "d1")
+                            fail_params["D2"] = input_with_help("D2", 0.25, "d2")
+                            fail_params["D3"] = input_with_help("D3", -0.5, "d3")
+                            fail_params["D4"] = input_with_help("D4", 0.014, "d4")
+                            fail_params["D5"] = input_with_help("D5", 1.12, "d5")
                         elif fail_type == "BIQUAD":
                             fail_params["C1"] = input_with_help("C1", 0.0, "c1")
                             fail_params["C2"] = input_with_help("C2", 0.0, "c2")


### PR DESCRIPTION
## Summary
- set default Johnson failure values in dashboard inputs
- write /FAIL/JOHNSON blocks with name line and defaults
- provide default failure parameters in material defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dd5d273dc832790f7ea03ee635b10