### PR TITLE
Fix gravity card in writer and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ La pestaña *Generar RAD* también permite definir condiciones de contorno
 
 (tarjetas ``/BCS``), contactos simples (``/INTER/TYPE2``) o generales
 (``/INTER/TYPE7``), velocidades iniciales (``/IMPVEL``) y cargas de
-gravedad (``/GRAVITY``) seleccionando las *name selections* de nodos en un
+gravedad (``/GRAV``) seleccionando las *name selections* de nodos en un
 desplegable. Estos campos se pueden editar, añadir o eliminar en el panel
 correspondiente antes de generar el archivo.
 El panel de gravedad está junto a **Velocidad inicial** y permite indicar la magnitud `g` y la dirección `(nx, ny, nz)`.

--- a/cdb2rad/rad_validator.py
+++ b/cdb2rad/rad_validator.py
@@ -47,7 +47,7 @@ KEYWORDS = (
     "/INTER/TYPE",
     "/FRICTION",
     "/IMPVEL",
-    "/GRAVITY",
+    "/GRAV",
     "/INCLUDE",
     "/NODE",
     "/GRNOD/GRNOD/",
@@ -210,11 +210,11 @@ def validate_rad_format(filepath: str) -> None:
             i += 1
             continue
 
-        if line.startswith("/GRAVITY"):
+        if line.startswith("/GRAV"):
             if i + 2 >= len(lines):
-                raise ValueError("Incomplete /GRAVITY block")
+                raise ValueError("Incomplete /GRAV block")
             if len(lines[i + 1].split()) != 2:
-                raise ValueError("/GRAVITY header format")
+                raise ValueError("/GRAV header format")
             if not all(_is_number(t) for t in lines[i + 2].split()):
                 raise ValueError("Invalid gravity vector")
             i += 3

--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -597,7 +597,7 @@ def write_rad(
             ny = gravity.get("ny", 0.0)
             nz = gravity.get("nz", -1.0)
             comp = int(gravity.get("comp", 3))
-            f.write("/GRAVITY\n")
+            f.write("/GRAV\n")
             f.write(f"{comp} {g}\n")
             f.write(f"{nx} {ny} {nz}\n")
 

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1091,7 +1091,7 @@ if file_path:
                         st.session_state["init_vel"] = None
                         _rerun()
 
-        with st.expander("Carga de gravedad (GRAVITY)"):
+        with st.expander("Carga de gravedad (/GRAV)"):
             g = input_with_help("g", 9.81, "grav_g")
             nx = input_with_help("nx", 0.0, "grav_nx")
             ny = input_with_help("ny", 0.0, "grav_ny")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -159,7 +159,7 @@ def test_write_rad_with_gravity(tmp_path):
     rad = tmp_path / 'grav.rad'
     write_rad(nodes, elements, str(rad), gravity={'g': 9.81, 'nz': -1.0})
     txt = rad.read_text()
-    assert '/GRAVITY' in txt
+    assert '/GRAV' in txt
 
 
 def test_write_rad_with_type7_contact(tmp_path):


### PR DESCRIPTION
## Summary
- update dashboard wording for gravity block
- use `/GRAV` keyword when writing the starter
- adjust RAD validator to recognise `/GRAV`
- update tests and docs accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dd756a824832784f43f2c8f2ca5f2