### PR TITLE
Fix TYPE2 interface validation

### DIFF
--- a/cdb2rad/rad_validator.py
+++ b/cdb2rad/rad_validator.py
@@ -174,11 +174,11 @@ def validate_rad_format(filepath: str) -> None:
             continue
 
         if line.startswith("/INTER/TYPE2"):
-            if i + 3 >= len(lines):
+            if i + 4 >= len(lines):
                 raise ValueError("Incomplete TYPE2 block")
-            if not lines[i + 2].startswith("/FRICTION"):
+            if not lines[i + 3].startswith("/FRICTION"):
                 raise ValueError("TYPE2 missing /FRICTION")
-            i += 4
+            i += 5
             continue
 
         if line.startswith("/RBODY/"):


### PR DESCRIPTION
## Summary
- adjust rad validator logic so `/INTER/TYPE2` matches writer output

## Testing
- `pytest -q`
- manual validation with a generated TYPE2 contact

------
https://chatgpt.com/codex/tasks/task_e_685de7d773808327a0028252ef56d979