### PR TITLE
Improve model config validation

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1300,23 +1300,40 @@ if file_path:
         )
         overwrite_rad = st.checkbox("Sobrescribir si existe", value=False, key="overwrite_rad")
 
+        adv_check = st.checkbox("Validación avanzada", key="adv_check")
         if st.button("Chequear configuracion"):
-            errs = check_rad_inputs(
+            st.session_state["config_results"] = check_rad_inputs(
                 use_cdb_mats,
                 materials,
                 use_impact,
                 st.session_state.get("impact_materials"),
                 st.session_state.get("bcs"),
                 st.session_state.get("interfaces"),
+                properties=st.session_state.get("properties"),
+                parts=st.session_state.get("parts"),
+                subsets=st.session_state.get("subsets"),
+                node_sets=all_node_sets,
+                nodes=all_nodes,
+                advanced=adv_check,
             )
-            if errs:
-                for e in errs:
-                    st.error(e)
-            else:
-                st.success("Configuracion OK")
+
+        results = st.session_state.get("config_results")
+        has_errors = False
+        if results:
+            for ok, msg in results:
+                if ok:
+                    st.write(f"✅ {msg}")
+                else:
+                    st.write(f"❌ {msg}")
+                    has_errors = True
+            st.session_state["config_ok"] = not has_errors
+        else:
+            st.session_state["config_ok"] = False
+
+        disable_gen = not st.session_state.get("config_ok", False)
 
 
-        if st.button("Generar .rad"):
+        if st.button("Generar .rad", disabled=disable_gen):
             out_dir = Path(rad_dir).expanduser()
             out_dir.mkdir(parents=True, exist_ok=True)
             rad_path = out_dir / f"{rad_name}.rad"

--- a/tests/test_check_inputs.py
+++ b/tests/test_check_inputs.py
@@ -1,0 +1,14 @@
+import cdb2rad.utils as utils
+
+def test_check_rad_inputs_basic():
+    res = utils.check_rad_inputs(
+        use_cdb_mats=True,
+        materials={1: {"LAW": "LAW1"}},
+        use_impact=False,
+        impact_materials=None,
+        bcs=None,
+        interfaces=None,
+        properties=[{"id": 1, "type": "SHELL", "thickness": 1.0}],
+        parts=[{"id": 1, "pid": 1, "mid": 1}],
+    )
+    assert all(ok for ok, _ in res)


### PR DESCRIPTION
## Summary
- extend `check_rad_inputs` with detailed validation checks
- display check results in dashboard and disable RAD generation when invalid
- add basic unit test for new validation function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e5bddeb108327aec6a7ad66fcde09