### PR TITLE
Split RAD file into starter and engine

### DIFF
--- a/cdb2rad/__init__.py
+++ b/cdb2rad/__init__.py
@@ -2,7 +2,7 @@
 
 from .parser import parse_cdb
 from .writer_inc import write_mesh_inc
-from .writer_rad import write_rad
+from .writer_rad import write_rad, write_starter, write_engine
 from .utils import element_summary
 from .remote import add_remote_point, next_free_node_id
 from .material_defaults import apply_default_materials
@@ -11,6 +11,8 @@ __all__ = [
     "parse_cdb",
     "write_mesh_inc",
     "write_rad",
+    "write_starter",
+    "write_engine",
     "element_summary",
     "apply_default_materials",
     "add_remote_point",

--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -41,6 +41,562 @@ DEFAULT_HISNODA_DT = None
 DEFAULT_RFILE_DT = None
 
 
+def write_starter(
+    nodes: Dict[int, List[float]],
+    elements: List[Tuple[int, int, List[int]]],
+    outfile: str,
+    mesh_inc: str = "mesh.inc",
+    include_inc: bool = True,
+    node_sets: Dict[str, List[int]] | None = None,
+    elem_sets: Dict[str, List[int]] | None = None,
+    materials: Dict[int, Dict[str, float]] | None = None,
+    extra_materials: Dict[int, Dict[str, float]] | None = None,
+    *,
+    thickness: float = DEFAULT_THICKNESS,
+    young: float = DEFAULT_E,
+    poisson: float = DEFAULT_NU,
+    density: float = DEFAULT_RHO,
+    runname: str = DEFAULT_RUNNAME,
+    boundary_conditions: List[Dict[str, object]] | None = None,
+    interfaces: List[Dict[str, object]] | None = None,
+    rbody: List[Dict[str, object]] | None = None,
+    rbe2: List[Dict[str, object]] | None = None,
+    rbe3: List[Dict[str, object]] | None = None,
+    init_velocity: Dict[str, object] | None = None,
+    gravity: Dict[str, float] | None = None,
+    properties: List[Dict[str, Any]] | None = None,
+    parts: List[Dict[str, Any]] | None = None,
+    subsets: Dict[str, List[int]] | None = None,
+    default_material: bool = True,
+) -> None:
+    """Write a Radioss starter file (``*_0000.rad``)."""
+
+    all_mats: Dict[int, Dict[str, float]] = {}
+    if materials:
+        all_mats.update(materials)
+    if extra_materials:
+        all_mats.update(extra_materials)
+    if all_mats:
+        all_mats = apply_default_materials(all_mats)
+
+    if include_inc:
+        write_mesh_inc(
+            nodes,
+            elements,
+            mesh_inc,
+            node_sets=node_sets,
+            elem_sets=elem_sets,
+            materials=all_mats if all_mats else None,
+        )
+
+    # Validate connector inputs
+    if rbody:
+        seen = set()
+        for rb in rbody:
+            rbid = rb.get("RBID")
+            if rbid in seen:
+                raise ValueError("Duplicate RBODY ID")
+            seen.add(rbid)
+            master = rb.get("Gnod_id")
+            if master not in nodes:
+                raise ValueError("RBODY master node missing")
+            for nid in rb.get("nodes", []):
+                if nid not in nodes:
+                    raise ValueError("RBODY node not found")
+
+    if rbe2:
+        seen = set()
+        for rb in rbe2:
+            mid = rb.get("N_master")
+            if mid not in nodes:
+                raise ValueError("RBE2 master node missing")
+            if mid in seen:
+                raise ValueError("Duplicate RBE2 master")
+            seen.add(mid)
+            for nid in rb.get("N_slave_list", []):
+                if nid not in nodes:
+                    raise ValueError("RBE2 slave node missing")
+
+    if rbe3:
+        for rb in rbe3:
+            dep = rb.get("N_dependent")
+            if dep not in nodes:
+                raise ValueError("RBE3 dependent node missing")
+            for nid, _ in rb.get("independent", []):
+                if nid not in nodes:
+                    raise ValueError("RBE3 independent node missing")
+
+    with open(outfile, "w") as f:
+        f.write("#RADIOSS STARTER\n")
+        f.write("/BEGIN\n")
+        f.write(f"{runname}\n")
+        f.write("     2024    0\n")
+        f.write("     kg      mm      ms\n")
+        f.write("     kg      mm      ms\n")
+
+        def write_law1(mid: int, name: str, rho: float, e: float, nu: float) -> None:
+            f.write(f"/MAT/LAW1/{mid}\n")
+            f.write(f"{name}\n")
+            f.write("#              RHO\n")
+            f.write(f"{rho}\n")
+            f.write("#                  E                  Nu\n")
+            f.write(f"{e} {nu}\n")
+
+        def write_law2(mid: int, name: str, rho: float, e: float, nu: float, a: float, b: float, n_val: float, c_val: float, eps0: float) -> None:
+            f.write(f"/MAT/LAW2/{mid}\n")
+            f.write(f"{name}\n")
+            f.write("#              RHO\n")
+            f.write(f"{rho}\n")
+            f.write("#                  E                  Nu\n")
+            f.write(f"{e} {nu}\n")
+            f.write("#      A          B           n           C       EPS0\n")
+            f.write(f"{a} {b} {n_val} {c_val} {eps0}\n")
+
+        def write_law27(mid: int, name: str, rho: float, e: float, nu: float, sig0: float, su: float, epsu: float) -> None:
+            f.write(f"/MAT/LAW27/{mid}\n")
+            f.write(f"{name}\n")
+            f.write("#              RHO\n")
+            f.write(f"{rho}\n")
+            f.write("#                  E                  Nu\n")
+            f.write(f"{e} {nu}\n")
+            f.write("#    SIG0        SU       EPSU\n")
+            f.write(f"{sig0} {su} {epsu}\n")
+
+        def write_law36(mid: int, name: str, rho: float, e: float, nu: float, fs: float, fc: float, ch: float, curve: list[tuple[float, float]] | None) -> None:
+            f.write(f"/MAT/LAW36/{mid}\n")
+            f.write(f"{name}\n")
+            f.write("#              RHO\n")
+            f.write(f"{rho}\n")
+            f.write("#                  E                  Nu\n")
+            f.write(f"{e} {nu}\n")
+            f.write("# fct_IDp  Fscale ...\n")
+            fct_id = 100 + mid
+            f.write(f"{fct_id} 1\n")
+            f.write("#     Fs        Fc        Ch\n")
+            f.write(f"{fs} {fc} {ch}\n")
+            if curve:
+                f.write(f"/FUNCT/{fct_id}\n")
+                f.write(f"{name} curve\n")
+                f.write("#     eps      \u03c3\n")
+                for eps, sig in curve:
+                    f.write(f"{eps} {sig}\n")
+
+        def write_law44(mid: int, name: str, rho: float, e: float, nu: float, a: float, b: float, n_val: float, c_val: float) -> None:
+            f.write(f"/MAT/LAW44/{mid}\n")
+            f.write(f"{name}\n")
+            f.write("#              RHO\n")
+            f.write(f"{rho}\n")
+            f.write("#                  E                  Nu\n")
+            f.write(f"{e} {nu}\n")
+            f.write("#      A          B           n           C\n")
+            f.write(f"{a} {b} {n_val} {c_val}\n")
+
+        if not all_mats:
+            if default_material:
+                write_law1(1, "Default_Mat", density, young, poisson)
+        else:
+            for mid, props in all_mats.items():
+                law = props.get("LAW", "LAW1").upper()
+                name = props.get("NAME", f"MAT_{mid}")
+                e = props.get("EX", young)
+                nu = props.get("NUXY", poisson)
+                rho = props.get("DENS", density)
+
+                if law in ("LAW2", "JOHNSON_COOK", "PLAS_JOHNS"):
+                    write_law2(
+                        mid,
+                        name,
+                        rho,
+                        e,
+                        nu,
+                        props.get("A", 0.0),
+                        props.get("B", 0.0),
+                        props.get("N", 0.0),
+                        props.get("C", 0.0),
+                        props.get("EPS0", 1.0),
+                    )
+                elif law in ("LAW27", "PLAS_BRIT"):
+                    write_law27(
+                        mid,
+                        name,
+                        rho,
+                        e,
+                        nu,
+                        props.get("SIG0", 0.0),
+                        props.get("SU", 0.0),
+                        props.get("EPSU", 0.0),
+                    )
+                elif law in ("LAW36", "PLAS_TAB"):
+                    curve = props.get("CURVE")
+                    write_law36(
+                        mid,
+                        name,
+                        rho,
+                        e,
+                        nu,
+                        props.get("Fsmooth", 0.0),
+                        props.get("Fcut", 0.0),
+                        props.get("Chard", 0.0),
+                        curve if isinstance(curve, list) else None,
+                    )
+                elif law in ("LAW44", "COWPER"):
+                    write_law44(
+                        mid,
+                        name,
+                        rho,
+                        e,
+                        nu,
+                        props.get("A", 0.0),
+                        props.get("B", 0.0),
+                        props.get("N", 1.0),
+                        props.get("C", 0.0),
+                    )
+                else:
+                    write_law1(mid, name, rho, e, nu)
+
+                if "FAIL" in props:
+                    fail = props["FAIL"]
+                    ftype = str(fail.get("TYPE", "")).upper()
+                    if ftype == "JOHNSON":
+                        d1 = fail.get("D1", -0.09)
+                        d2 = fail.get("D2", 0.25)
+                        d3 = fail.get("D3", -0.5)
+                        d4 = fail.get("D4", 0.014)
+                        d5 = fail.get("D5", 1.12)
+                        eps0 = fail.get("EPS0", 1.0)
+                        ifail_sh = fail.get("IFAIL_SH", 1)
+                        ifail_so = fail.get("IFAIL_SO", 1)
+                        dadv = fail.get("DADV", 0)
+                        ixfem = fail.get("IXFEM", 0)
+                        f.write(f"/FAIL/JOHNSON/{mid}\n")
+                        f.write(f"{d1} {d2} {d3} {d4} {d5}\n")
+                        f.write(f"{eps0} {ifail_sh} {ifail_so}\n")
+                        f.write(f"{dadv}\n")
+                        f.write(f"{ixfem}\n")
+                    elif ftype == "BIQUAD":
+                        alpha = fail.get("ALPHA", 0.0)
+                        beta = fail.get("BETA", 0.0)
+                        m = fail.get("M", 0.0)
+                        n_fail = fail.get("N", 0.0)
+                        f.write(f"/FAIL/BIQUAD/{mid}\n")
+                        f.write("#    alpha      beta      m      n\n")
+                        f.write(f"  {alpha}   {beta}   {m}   {n_fail}\n")
+                    elif ftype:
+                        f.write(f"/FAIL/{ftype}/{mid}\n")
+                        vals = [str(v) for k, v in fail.items() if k not in {"TYPE", "NAME"}]
+                        if vals:
+                            f.write(" ".join(vals) + "\n")
+
+        if include_inc:
+            f.write(f"#include {mesh_inc}\n")
+
+        if boundary_conditions:
+            for idx, bc in enumerate(boundary_conditions, start=1):
+                bc_type = str(bc.get("type", "BCS")).upper()
+                name = bc.get("name", f"BC_{idx}")
+                nodes_bc = bc.get("nodes", [])
+                gid = 100 + idx
+
+                if bc_type == "BCS":
+                    tra = str(bc.get("tra", "000")).rjust(3, "0")
+                    rot = str(bc.get("rot", "000")).rjust(3, "0")
+                    f.write(f"/BCS/{idx}\n")
+                    f.write(f"{name}\n")
+                    f.write("#  Trarot   Skew_ID  grnd_ID\n")
+                    f.write(f"   {tra} {rot}         0        {gid}\n")
+                elif bc_type == "PRESCRIBED_MOTION":
+                    direction = int(bc.get("dir", 1))
+                    value = float(bc.get("value", 0.0))
+                    f.write(f"/BOUNDARY/PRESCRIBED_MOTION/{idx}\n")
+                    f.write(f"{name}\n")
+                    f.write("#   Dir    skew_ID   grnod_ID\n")
+                    f.write(f"    {direction}        0        {gid}\n")
+                    f.write(f"{value}\n")
+                else:
+                    f.write(f"# Unsupported BC type: {bc_type}\n")
+                    continue
+
+                f.write(f"/GRNOD/NODE/{gid}\n")
+                f.write(f"{name}_nodes\n")
+                for nid in nodes_bc:
+                    f.write(f"{nid:10d}\n")
+
+        if interfaces:
+            for idx, inter in enumerate(interfaces, start=1):
+                itype = inter.get("type", "TYPE2").upper()
+                s_nodes = inter.get("slave", [])
+                m_nodes = inter.get("master", [])
+                name = inter.get("name", f"INTER_{idx}")
+                fric = inter.get("fric", 0.0)
+                slave_id = 200 + idx
+                master_id = 300 + idx
+
+                if itype == "TYPE7":
+                    gap = inter.get("gap", 0.0)
+                    stif = inter.get("stiff", 0.0)
+                    igap = inter.get("igap", 0)
+                    f.write(f"/INTER/TYPE7/{idx}\n")
+                    f.write(f"{name}\n")
+                    f.write(f"{slave_id} {master_id} {stif} {gap} {igap}\n")
+                    f.write("/FRICTION\n")
+                    f.write(f"{fric}\n")
+                else:
+                    f.write(f"/INTER/TYPE2/{idx}\n")
+                    f.write(f"{name}\n")
+                    f.write(f"{slave_id} {master_id}\n")
+                    f.write("/FRICTION\n")
+                    f.write(f"{fric}\n")
+
+                f.write(f"/GRNOD/NODE/{slave_id}\n")
+                f.write(f"{name}_slave\n")
+                for nid in s_nodes:
+                    f.write(f"{nid:10d}\n")
+                f.write(f"/GRNOD/NODE/{master_id}\n")
+                f.write(f"{name}_master\n")
+                for nid in m_nodes:
+                    f.write(f"{nid:10d}\n")
+
+        if rbody:
+            for idx, rb in enumerate(rbody, start=1):
+                title = rb.get("title", "")
+                f.write(f"/RBODY/{idx}\n")
+                f.write(f"{title}\n")
+                f.write("#     RBID  ISENS  NSKEW  ISPHER   MASS  Gnod_id  IKREM  ICOG  Surf_id\n")
+                f.write(
+                    f"     {rb.get('RBID',0)}     {rb.get('ISENS',0)}      {rb.get('NSKEW',0)}       {rb.get('ISPHER',0)}      {rb.get('MASS',0)}    {rb.get('Gnod_id',0)}     {rb.get('IKREM',0)}     {rb.get('ICOG',0)}       {rb.get('SURF_ID',0)}\n"
+                )
+                f.write("#     Jxx     Jyy     Jzz\n")
+                f.write(
+                    f"        {rb.get('Jxx',0)}       {rb.get('Jyy',0)}       {rb.get('Jzz',0)}\n"
+                )
+                f.write("#     Jxy     Jyz     Jxz\n")
+                f.write(
+                    f"        {rb.get('Jxy',0)}       {rb.get('Jyz',0)}       {rb.get('Jxz',0)}\n"
+                )
+                f.write("#     Ioptoff  Ifail\n")
+                f.write(
+                    f"     {rb.get('Ioptoff',0)}     {rb.get('Ifail',0)}\n"
+                )
+
+        if rbe2:
+            for idx, rb in enumerate(rbe2, start=1):
+                name = rb.get("name", f"RBE2_{idx}")
+                f.write(f"/RBE2/{idx}\n")
+                f.write(f"{name}\n")
+                f.write("#  N_master   DOF_flags   MSELECT\n")
+                f.write(
+                    f"   {rb.get('N_master',0)}     {rb.get('DOF_flags','123456')}       {rb.get('MSELECT',1)}\n"
+                )
+                f.write("#  N_slave_list\n")
+                slaves = rb.get('N_slave_list', [])
+                if slaves:
+                    f.write("   " + "   ".join(str(n) for n in slaves) + "\n")
+
+        if rbe3:
+            for idx, rb in enumerate(rbe3, start=1):
+                name = rb.get("name", f"RBE3_{idx}")
+                f.write(f"/RBE3/{idx}\n")
+                f.write(f"{name}\n")
+                f.write("#  N_dependent  DOF_flags   MSELECT\n")
+                f.write(
+                    f"   {rb.get('N_dependent',0)}        {rb.get('DOF_flags','123456')}        {rb.get('MSELECT',0)}\n"
+                )
+                f.write("#  N_indep  Weight\n")
+                for nid, wt in rb.get('independent', []):
+                    f.write(f"   {nid}     {wt}\n")
+
+        if parts:
+            for p in parts:
+                pid = int(p.get("id", 1))
+                name = p.get("name", f"PART_{pid}")
+                prop_id = int(p.get("pid", 1))
+                mat_id = int(p.get("mid", 1))
+                f.write(f"/PART/{pid}\n")
+                f.write(f"{name}\n")
+                f.write(f"         {prop_id}         {mat_id}         0\n")
+
+        if properties:
+            for prop in properties:
+                pid = int(prop.get("id", 1))
+                pname = prop.get("name", f"PROP_{pid}")
+                ptype = str(prop.get("type", "SHELL")).upper()
+                if ptype == "SHELL":
+                    thick = prop.get("thickness", thickness)
+                    ishell = int(prop.get("Ishell", 24))
+                    ismstr = int(prop.get("Ismstr", 0))
+                    ish3n = int(prop.get("Ish3n", 0))
+                    idrill = int(prop.get("Idrill", 0))
+                    p_thick_fail = float(prop.get("P_thick_fail", 0))
+                    hm = float(prop.get("hm", 0))
+                    hf = float(prop.get("hf", 0))
+                    hr = float(prop.get("hr", 0))
+                    dm = float(prop.get("dm", 0))
+                    dn = float(prop.get("dn", 0))
+                    n = int(prop.get("N", 5))
+                    istr = int(prop.get("Istrain", 0))
+                    ashear = int(prop.get("Ashear", 0))
+                    ithick = int(prop.get("Ithick", 1))
+                    ip = int(prop.get("Iplas", 1))
+
+                    f.write(f"/PROP/SHELL/{pid}\n")
+                    f.write(f"{pname}\n")
+                    f.write("#   Ishell    Ismstr     Ish3n    Idrill              P_thick_fail\n")
+                    f.write(f"        {ishell}         {ismstr}         {ish3n}        {idrill}                            {p_thick_fail}\n")
+                    f.write("#                 hm                  hf            hr                  dm                  dn\n")
+                    f.write(f"                   {hm}                   {hf}            {hr}                   {dm}                   {dn}\n")
+                    f.write("#        N   Istrain               Thick   Ashear              Ithick     Iplas\n")
+                    f.write(f"         {n}         {istr}                 {thick}                   {ashear}                   {ithick}         {ip}\n")
+                elif ptype == "SOLID":
+                    isol = int(prop.get("Isolid", 24))
+                    ismstr = int(prop.get("Ismstr", 4))
+                    icpre = int(prop.get("Icpre", 1))
+                    iframe = int(prop.get("Iframe", 1))
+                    inpts = int(prop.get("Inpts", 222))
+                    qa = float(prop.get("qa", 1.1))
+                    qb = float(prop.get("qb", 0.05))
+                    dn = float(prop.get("dn", 0.1))
+                    h = float(prop.get("h", 0.0))
+
+                    f.write(f"/PROP/SOLID/{pid}\n")
+                    f.write(f"{pname}\n")
+                    f.write("#  Isolid   Ismstr    Icpre   Iframe\n")
+                    f.write(
+                        f"       {isol}        {ismstr}        {icpre}        {iframe}\n"
+                    )
+                    f.write("#  Inpts       qa        qb        dn         h\n")
+                    f.write(
+                        f"   {inpts:5d}   {qa:<8g}   {qb:<8g}   {dn:<8g}   {h:<8g}\n"
+                    )
+                else:
+                    f.write(f"/PROP/{ptype}/{pid}\n")
+                    f.write(f"{pname}\n")
+                    f.write("# property parameters not defined\n")
+
+        if subsets:
+            for idx, (name, ids) in enumerate(subsets.items(), start=1):
+                f.write(f"/SUBSET/{idx}\n")
+                f.write(f"{name}\n")
+                line: List[str] = []
+                for i, sid in enumerate(ids, 1):
+                    line.append(str(sid))
+                    if i % 10 == 0:
+                        f.write(" ".join(line) + "\n")
+                        line = []
+                if line:
+                    f.write(" ".join(line) + "\n")
+
+        if init_velocity:
+            nodes_v = init_velocity.get("nodes", [])
+            vx = init_velocity.get("vx", 0.0)
+            vy = init_velocity.get("vy", 0.0)
+            vz = init_velocity.get("vz", 0.0)
+            gid = 400
+            f.write("/IMPVEL/1\n")
+            f.write("0         X         0         0        400         0        0\n")
+            f.write(f"{vx} {vy} {vz} 0\n")
+            f.write(f"/GRNOD/NODE/{gid}\n")
+            f.write("Init_Vel_Nodes\n")
+            for nid in nodes_v:
+                f.write(f"{nid:10d}\n")
+
+        if gravity:
+            g = float(gravity.get("g", 9.81))
+            nx = float(gravity.get("nx", 0.0))
+            ny = float(gravity.get("ny", 0.0))
+            nz = float(gravity.get("nz", -1.0))
+            comp = int(gravity.get("comp", 3))
+            mag = math.sqrt(nx * nx + ny * ny + nz * nz)
+            if mag:
+                nx /= mag
+                ny /= mag
+                nz /= mag
+            f.write("/GRAV\n")
+            f.write(f"{comp} {g}\n")
+            f.write(f"{nx} {ny} {nz}\n")
+
+        f.write("/END\n")
+
+
+def write_engine(
+    outfile: str,
+    *,
+    runname: str = DEFAULT_RUNNAME,
+    t_end: float = DEFAULT_FINAL_TIME,
+    t_init: float = 0.0,
+    anim_dt: float | None = DEFAULT_ANIM_DT,
+    shell_anim_dt: float | None = DEFAULT_SHELL_ANIM_DT,
+    brick_anim_dt: float | None = DEFAULT_BRICK_ANIM_DT,
+    tfile_dt: float | None = DEFAULT_HISTORY_DT,
+    hisnoda_dt: float | None = DEFAULT_HISNODA_DT,
+    dt_ratio: float | None = DEFAULT_DT_RATIO,
+    rfile_dt: float | None = DEFAULT_RFILE_DT,
+    print_n: int | None = DEFAULT_PRINT_N,
+    print_line: int | None = DEFAULT_PRINT_LINE,
+    rfile_cycle: int | None = None,
+    rfile_n: int | None = None,
+    h3d_dt: float | None = None,
+    stop_emax: float = DEFAULT_STOP_EMAX,
+    stop_mmax: float = DEFAULT_STOP_MMAX,
+    stop_nmax: float = DEFAULT_STOP_NMAX,
+    stop_nth: int = DEFAULT_STOP_NTH,
+    stop_nanim: int = DEFAULT_STOP_NANIM,
+    stop_nerr: int = DEFAULT_STOP_NERR,
+    out_ascii: bool = False,
+    adyrel: Tuple[float | None, float | None] | None = None,
+) -> None:
+    """Write a Radioss engine file (``*_0001.rad``)."""
+
+    with open(outfile, "w") as f:
+        f.write("#RADIOSS ENGINE\n")
+        if print_n is not None and print_line is not None:
+            f.write(f"/PRINT/{print_n}/{print_line}\n")
+        f.write(f"/RUN/{runname}/1\n")
+        if t_init != 0.0:
+            f.write(f"{t_init} {t_end}\n")
+        else:
+            f.write(f"                {t_end}\n")
+        f.write("/STOP\n")
+        f.write(f"{stop_emax} {stop_mmax} {stop_nmax} {stop_nth} {stop_nanim} {stop_nerr}\n")
+        if tfile_dt is not None:
+            f.write("/TFILE/0\n")
+            f.write(f"{tfile_dt}\n")
+        f.write("/VERS/2024\n")
+        if dt_ratio is not None:
+            f.write("/DT/NODA/CST/0\n")
+            f.write(f"{dt_ratio} 0 0\n")
+        if anim_dt is not None:
+            f.write("/ANIM/DT\n")
+            f.write(f"0 {anim_dt}\n")
+        if shell_anim_dt is not None:
+            f.write("/ANIM/SHELL/DT\n")
+            f.write(f"0 {shell_anim_dt}\n")
+        if brick_anim_dt is not None:
+            f.write("/ANIM/BRICK/DT\n")
+            f.write(f"0 {brick_anim_dt}\n")
+        if h3d_dt is not None:
+            f.write("/H3D/DT\n")
+            f.write(f"0 {h3d_dt}\n")
+        if hisnoda_dt is not None:
+            f.write("/HISNODA/DT\n")
+            f.write(f"{hisnoda_dt}\n")
+        if rfile_cycle is not None:
+            if rfile_n is not None:
+                f.write(f"/RFILE/{rfile_n}\n")
+            else:
+                f.write("/RFILE\n")
+            f.write(f"{rfile_cycle}\n")
+        if rfile_dt is not None:
+            f.write("/RFILE/DT\n")
+            f.write(f"{rfile_dt}\n")
+        if out_ascii:
+            f.write("/OUTP/ASCII\n")
+        if adyrel is not None and (adyrel[0] is not None or adyrel[1] is not None):
+            f.write("/ADYREL\n")
+            tstart = 0.0 if adyrel[0] is None else adyrel[0]
+            tstop = t_end if adyrel[1] is None else adyrel[1]
+            f.write(f"{tstart} {tstop}\n")
+
+
 def write_rad(
     nodes: Dict[int, List[float]],
     elements: List[Tuple[int, int, List[int]]],

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -11,13 +11,14 @@ if str(ROOT) not in sys.path:
 
 from cdb2rad.parser import parse_cdb
 from cdb2rad.writer_inc import write_mesh_inc
-from cdb2rad.writer_rad import write_rad
+from cdb2rad.writer_rad import write_starter, write_engine
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Process .cdb file")
     parser.add_argument("cdb_file", help="Input .cdb file")
-    parser.add_argument("--rad", dest="rad", help="Output .rad file")
+    parser.add_argument("--starter", dest="starter", help="Output starter file")
+    parser.add_argument("--engine", dest="engine", help="Output engine file")
     parser.add_argument("--inc", dest="inc", help="Output mesh.inc file")
     parser.add_argument("--exec", dest="exec_path", help="Run OpenRadioss starter after generation")
     parser.add_argument(
@@ -38,10 +39,10 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    if not args.rad and not args.inc:
-        # default output names when none are provided
+    if not args.starter and not args.engine and not args.inc:
         args.inc = "mesh.inc"
-        args.rad = "model_0000.rad"
+        args.starter = "model_0000.rad"
+        args.engine = "model_0001.rad"
 
     nodes, elements, node_sets, elem_sets, materials = parse_cdb(args.cdb_file)
 
@@ -54,21 +55,25 @@ def main() -> None:
             elem_sets=elem_sets,
             materials=materials,
         )
-    if args.rad:
-        write_rad(
+    if args.starter:
+        write_starter(
             nodes,
             elements,
-            args.rad,
+            args.starter,
             mesh_inc=args.inc or "mesh.inc",
             include_inc=not args.skip_include,
-            include_run=not args.no_run_cards,
-            default_material=not args.no_default_material,
             node_sets=node_sets,
             elem_sets=elem_sets,
             materials=materials,
+            default_material=not args.no_default_material,
         )
-        if args.exec_path:
-            subprocess.run([args.exec_path, '-i', args.rad], check=False)
+    if args.engine:
+        write_engine(
+            args.engine,
+            runname=Path(args.starter or "model").stem.replace("_0000", ""),
+        )
+        if args.exec_path and args.starter:
+            subprocess.run([args.exec_path, '-i', args.starter], check=False)
 
 
 if __name__ == "__main__":

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1296,7 +1296,7 @@ if file_path:
             key="rad_dir",
         )
         rad_name = st.text_input(
-            "Nombre de archivo RAD", value="model_0000", key="rad_name"
+            "Nombre base RAD", value="model", key="rad_name"
         )
         overwrite_rad = st.checkbox("Sobrescribir si existe", value=False, key="overwrite_rad")
 
@@ -1333,10 +1333,10 @@ if file_path:
         disable_gen = not st.session_state.get("config_ok", False)
 
 
-        if st.button("Generar .rad", disabled=disable_gen):
+        if st.button("Generar starter", disabled=disable_gen):
             out_dir = Path(rad_dir).expanduser()
             out_dir.mkdir(parents=True, exist_ok=True)
-            rad_path = out_dir / f"{rad_name}.rad"
+            rad_path = out_dir / f"{rad_name}_0000.rad"
             mesh_path = out_dir / "mesh.inc"
             impact_defined = use_impact and st.session_state.get("impact_materials")
             if (rad_path.exists() or mesh_path.exists()) and not overwrite_rad:
@@ -1377,7 +1377,7 @@ if file_path:
                 if not include_inc:
                     write_mesh_inc(all_nodes, elements, str(mesh_path), node_sets=all_node_sets)
                 all_elem_sets = {**elem_sets, **st.session_state.get("subsets", {})}
-                write_rad(
+                write_starter(
                         all_nodes,
                         elements,
                         str(rad_path),
@@ -1387,30 +1387,7 @@ if file_path:
                         elem_sets=all_elem_sets,
                         materials=materials if use_cdb_mats else None,
                         extra_materials=extra,
-
                         runname=runname,
-                        t_end=t_end,
-                        t_init=t_init,
-                        anim_dt=anim_dt,
-                        shell_anim_dt=shell_anim_dt,
-                        brick_anim_dt=brick_anim_dt,
-                        tfile_dt=tfile_dt,
-                        hisnoda_dt=hisnoda_dt,
-                        dt_ratio=dt_ratio,
-                        rfile_dt=rfile_dt,
-                        print_n=int(print_n) if print_n is not None else None,
-                        print_line=int(print_line) if print_line is not None else None,
-                        rfile_cycle=int(rfile_cycle) if rfile_cycle else None,
-                        rfile_n=int(rfile_n) if rfile_n else None,
-                        out_ascii=out_ascii,
-                        h3d_dt=h3d_dt if (h3d_dt is not None and h3d_dt > 0) else None,
-                        stop_emax=stop_emax,
-                        stop_mmax=stop_mmax,
-                        stop_nmax=stop_nmax,
-                        stop_nth=int(stop_nth),
-                        stop_nanim=int(stop_nanim),
-                        stop_nerr=int(stop_nerr),
-                        adyrel=(adyrel_start, adyrel_stop),
 
                         boundary_conditions=st.session_state.get("bcs"),
                         interfaces=st.session_state.get("interfaces"),
@@ -1431,8 +1408,73 @@ if file_path:
                 st.success(f"Ficheros generados en: {rad_path}")
                 with st.expander("Ver .rad completo"):
                     st.text_area(
-                        "model.rad", rad_path.read_text(), height=400
+                        "model_0000.rad", rad_path.read_text(), height=400
                     )
+
+        if st.button("Generar engine", disabled=disable_gen):
+            out_dir = Path(rad_dir).expanduser()
+            out_dir.mkdir(parents=True, exist_ok=True)
+            eng_path = out_dir / f"{rad_name}_0001.rad"
+            ctrl = st.session_state.get("control_settings")
+            if ctrl:
+                runname = ctrl.get("runname", runname)
+                t_end = ctrl.get("t_end", t_end)
+                t_init = ctrl.get("t_init", t_init)
+                anim_dt = ctrl.get("anim_dt", anim_dt)
+                shell_anim_dt = ctrl.get("shell_anim_dt", shell_anim_dt)
+                brick_anim_dt = ctrl.get("brick_anim_dt", brick_anim_dt)
+                tfile_dt = ctrl.get("tfile_dt", tfile_dt)
+                hisnoda_dt = ctrl.get("hisnoda_dt", hisnoda_dt)
+                dt_ratio = ctrl.get("dt_ratio", dt_ratio)
+                rfile_dt = ctrl.get("rfile_dt", rfile_dt)
+                print_n = ctrl.get("print_n", print_n)
+                print_line = ctrl.get("print_line", print_line)
+                rfile_cycle = ctrl.get("rfile_cycle", rfile_cycle)
+                rfile_n = ctrl.get("rfile_n", rfile_n)
+                out_ascii = ctrl.get("out_ascii", out_ascii)
+                h3d_dt = ctrl.get("h3d_dt", h3d_dt)
+                stop_emax = ctrl.get("stop_emax", stop_emax)
+                stop_mmax = ctrl.get("stop_mmax", stop_mmax)
+                stop_nmax = ctrl.get("stop_nmax", stop_nmax)
+                stop_nth = ctrl.get("stop_nth", stop_nth)
+                stop_nanim = ctrl.get("stop_nanim", stop_nanim)
+                stop_nerr = ctrl.get("stop_nerr", stop_nerr)
+                adyrel_start = ctrl.get("adyrel_start", adyrel_start)
+                adyrel_stop = ctrl.get("adyrel_stop", adyrel_stop)
+            write_engine(
+                str(eng_path),
+                runname=runname,
+                t_end=t_end,
+                t_init=t_init,
+                anim_dt=anim_dt,
+                shell_anim_dt=shell_anim_dt,
+                brick_anim_dt=brick_anim_dt,
+                tfile_dt=tfile_dt,
+                hisnoda_dt=hisnoda_dt,
+                dt_ratio=dt_ratio,
+                rfile_dt=rfile_dt,
+                print_n=int(print_n) if print_n is not None else None,
+                print_line=int(print_line) if print_line is not None else None,
+                rfile_cycle=int(rfile_cycle) if rfile_cycle else None,
+                rfile_n=int(rfile_n) if rfile_n else None,
+                out_ascii=out_ascii,
+                h3d_dt=h3d_dt if (h3d_dt is not None and h3d_dt > 0) else None,
+                stop_emax=stop_emax,
+                stop_mmax=stop_mmax,
+                stop_nmax=stop_nmax,
+                stop_nth=int(stop_nth),
+                stop_nanim=int(stop_nanim),
+                stop_nerr=int(stop_nerr),
+                adyrel=(adyrel_start, adyrel_stop),
+            )
+            try:
+                validate_rad_format(str(eng_path))
+                st.info("Formato RAD OK")
+            except ValueError as e:
+                st.error(f"Error formato: {e}")
+            st.success(f"Ficheros generados en: {eng_path}")
+            with st.expander("Ver engine"):
+                st.text_area("model_0001.rad", eng_path.read_text(), height=400)
 
     with help_tab:
         st.subheader("Documentación")

--- a/tests/test_material_section.py
+++ b/tests/test_material_section.py
@@ -1,6 +1,6 @@
 import os
 from cdb2rad.parser import parse_cdb
-from cdb2rad.writer_rad import write_rad
+from cdb2rad.writer_rad import write_starter
 
 DATA = os.path.join(os.path.dirname(__file__), '..', 'data', 'model.cdb')
 
@@ -14,8 +14,8 @@ def test_material_blocks(tmp_path):
             'CURVE': [(0.0, 300.0), (0.1, 400.0)],
         }
     }
-    rad = tmp_path / 'mat.rad'
-    write_rad(
+    rad = tmp_path / 'mat_0000.rad'
+    write_starter(
         nodes,
         elements,
         str(rad),

--- a/tests/test_openradioss_run.py
+++ b/tests/test_openradioss_run.py
@@ -3,7 +3,7 @@ import subprocess
 from pathlib import Path
 import pytest
 from cdb2rad.parser import parse_cdb
-from cdb2rad.writer_rad import write_rad
+from cdb2rad.writer_rad import write_starter, write_engine
 
 DATA = Path(__file__).resolve().parents[1] / 'data' / 'model.cdb'
 EXEC = Path(__file__).resolve().parents[1] / 'openradioss_bin' / 'OpenRadioss' / 'exec' / 'starter_linux64_gf'
@@ -13,10 +13,12 @@ CFGDIR = Path(__file__).resolve().parents[1] / 'openradioss_bin' / 'OpenRadioss'
 @pytest.mark.skipif(not EXEC.exists(), reason="OpenRadioss binary not installed")
 def test_run_starter(tmp_path):
     nodes, elements, node_sets, elem_sets, mats = parse_cdb(str(DATA))
-    rad = tmp_path / 'model_0000.rad'
-    write_rad(nodes, elements, str(rad), node_sets=node_sets, elem_sets=elem_sets, materials=mats)
+    starter = tmp_path / 'model_0000.rad'
+    engine = tmp_path / 'model_0001.rad'
+    write_starter(nodes, elements, str(starter), node_sets=node_sets, elem_sets=elem_sets, materials=mats)
+    write_engine(str(engine))
     env = os.environ.copy()
     env['LD_LIBRARY_PATH'] = str(LIBDIR)
     env['RAD_CFG_PATH'] = str(CFGDIR)
-    result = subprocess.run([str(EXEC), '-i', str(rad)], env=env, capture_output=True, text=True)
+    result = subprocess.run([str(EXEC), '-i', str(starter)], env=env, capture_output=True, text=True)
     assert 'OpenRadioss Starter' in result.stdout

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 from cdb2rad.parser import parse_cdb
-from cdb2rad.writer_rad import write_rad
+from cdb2rad.writer_rad import write_starter, write_engine
 from cdb2rad.rad_validator import validate_rad_format
 
 DATA = os.path.join(os.path.dirname(__file__), '..', 'data', 'model.cdb')
@@ -22,11 +22,12 @@ def test_validate_examples(example):
 
 def test_generated_rad_format(tmp_path):
     nodes, elements, node_sets, elem_sets, mats = parse_cdb(DATA)
-    rad = tmp_path / 'model.rad'
-    write_rad(
+    starter = tmp_path / 'model_0000.rad'
+    engine = tmp_path / 'model_0001.rad'
+    write_starter(
         nodes,
         elements,
-        str(rad),
+        str(starter),
         node_sets=node_sets,
         elem_sets=elem_sets,
         materials=mats,
@@ -35,7 +36,9 @@ def test_generated_rad_format(tmp_path):
         init_velocity={'nodes': [1], 'vx': 1.0},
         gravity={'g': 9.81, 'nz': -1.0},
     )
-    validate_rad_format(str(rad))
+    write_engine(str(engine))
+    validate_rad_format(str(starter))
+    validate_rad_format(str(engine))
 
 
 def test_invalid_keyword(tmp_path):


### PR DESCRIPTION
## Summary
- add `write_starter` and `write_engine` APIs and export them
- update CLI and GUI to generate `*_0000.rad` and `*_0001.rad`
- revise tests for new starter/engine split

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eb999c09c832780563018d7ce6a8e