### PR TITLE
Fix dashboard starter call

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -114,6 +114,7 @@ DEFAULT_VTK_DIR = r"C:\JAVIER\OPEN_RADIOSS\paraview\data"
 from cdb2rad.parser import parse_cdb
 from cdb2rad.writer_rad import (
     write_rad,
+    write_starter,
     DEFAULT_RUNNAME,
     DEFAULT_FINAL_TIME,
     DEFAULT_ANIM_DT,


### PR DESCRIPTION
## Summary
- import `write_starter` for the Streamlit dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ec846fa4083279c7fd69b6d0baf6b