### PR TITLE
Fix dashboard engine import

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -115,6 +115,7 @@ from cdb2rad.parser import parse_cdb
 from cdb2rad.writer_rad import (
     write_rad,
     write_starter,
+    write_engine,
     DEFAULT_RUNNAME,
     DEFAULT_FINAL_TIME,
     DEFAULT_ANIM_DT,


### PR DESCRIPTION
## Summary
- import `write_engine` in dashboard app so engine files can be generated

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ec93fdc788327b6a922c2c7f5e58e