### PR TITLE
Fix material ID mapping in PART cards

### DIFF
--- a/tests/test_part_mapping.py
+++ b/tests/test_part_mapping.py
@@ -1,0 +1,29 @@
+import os
+from cdb2rad.parser import parse_cdb
+from cdb2rad.writer_rad import write_starter
+
+DATA = os.path.join(os.path.dirname(__file__), '..', 'data', 'model.cdb')
+
+
+def test_part_material_mapping(tmp_path):
+    nodes, elements, node_sets, elem_sets, mats = parse_cdb(DATA)
+    props = [{'id': 1, 'name': 'shell_p', 'type': 'SHELL', 'thickness': 1.0}]
+    parts = [{'id': 1, 'name': 'part1', 'pid': 1, 'mid': 1}]
+    extra = {1: {'LAW': 'LAW1', 'EX': 1e5, 'NUXY': 0.3, 'DENS': 7800.0}}
+    rad = tmp_path / 'mapped_0000.rad'
+    write_starter(
+        nodes,
+        elements,
+        str(rad),
+        node_sets=node_sets,
+        elem_sets=elem_sets,
+        materials=mats,
+        extra_materials=extra,
+        properties=props,
+        parts=parts,
+    )
+    lines = rad.read_text().splitlines()
+    idx = lines.index('/PART/1')
+    mat_id = int(lines[idx + 2].split()[1])
+    assert mat_id != 1
+    assert any(line.startswith(f'/MAT/LAW1/{mat_id}') for line in lines)


### PR DESCRIPTION
## Summary
- ensure material IDs are remapped when merging material dictionaries
- update PART writing logic to use the remapped IDs
- add regression test for material ID mapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed611e2d0832780fca59845c9100f