### PR TITLE
Fix material ID clashes when adding custom materials

### DIFF
--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -41,6 +41,27 @@ DEFAULT_HISNODA_DT = None
 DEFAULT_RFILE_DT = None
 
 
+def _merge_materials(
+    base: Dict[int, Dict[str, float]] | None,
+    extra: Dict[int, Dict[str, float]] | None,
+) -> Dict[int, Dict[str, float]]:
+    """Merge two material dictionaries avoiding ID collisions."""
+    result: Dict[int, Dict[str, float]] = {}
+    max_id = 0
+    if base:
+        result.update(base)
+        max_id = max(base.keys(), default=0)
+    if extra:
+        for mid, props in extra.items():
+            if mid in result:
+                max_id += 1
+                result[max_id] = props
+            else:
+                result[mid] = props
+                max_id = max(max_id, mid)
+    return result
+
+
 def write_starter(
     nodes: Dict[int, List[float]],
     elements: List[Tuple[int, int, List[int]]],
@@ -71,11 +92,7 @@ def write_starter(
 ) -> None:
     """Write a Radioss starter file (``*_0000.rad``)."""
 
-    all_mats: Dict[int, Dict[str, float]] = {}
-    if materials:
-        all_mats.update(materials)
-    if extra_materials:
-        all_mats.update(extra_materials)
+    all_mats = _merge_materials(materials, extra_materials)
     if all_mats:
         all_mats = apply_default_materials(all_mats)
 
@@ -664,11 +681,7 @@ def write_rad(
     provided.
     """
 
-    all_mats: Dict[int, Dict[str, float]] = {}
-    if materials:
-        all_mats.update(materials)
-    if extra_materials:
-        all_mats.update(extra_materials)
+    all_mats = _merge_materials(materials, extra_materials)
     if all_mats:
         all_mats = apply_default_materials(all_mats)
 

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -691,9 +691,11 @@ if file_path:
 
             if use_impact:
                 with st.expander("Materiales de impacto"):
+                    max_mid = max(materials.keys(), default=0) if use_cdb_mats else 0
+                    default_mid = max_mid + len(st.session_state["impact_materials"]) + 1
                     mat_id = input_with_help(
                         "ID material",
-                        len(st.session_state["impact_materials"]) + 1,
+                        default_mid,
                         "mat_id",
                     )
                     law = st.selectbox(


### PR DESCRIPTION
## Summary
- prevent material ID collisions by merging dictionaries with unique IDs
- default dashboard material IDs after the highest CDB ID
- test that duplicate material IDs are offset automatically
- adjust dashboard toggle for CDB materials
- test that impact-only materials keep their IDs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed47317a883278725b17ee8e640f9