### PR TITLE
Fix contact interface writing

### DIFF
--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -76,6 +76,47 @@ def _merge_materials(
     return result, id_map
 
 
+def _write_interfaces(f, interfaces: List[Dict[str, object]] | None) -> None:
+    """Write ``/INTER`` blocks to ``f`` if any interfaces are defined."""
+
+    if not interfaces:
+        return
+
+    for idx, inter in enumerate(interfaces, start=1):
+        itype = str(inter.get("type", "TYPE2")).upper()
+        s_nodes = inter.get("slave", [])
+        m_nodes = inter.get("master", [])
+        name = inter.get("name", f"INTER_{idx}")
+        fric = inter.get("fric", 0.0)
+        slave_id = 200 + idx
+        master_id = 300 + idx
+
+        if itype == "TYPE7":
+            gap = inter.get("gap", 0.0)
+            stiff = inter.get("stiff", 0.0)
+            igap = inter.get("igap", 0)
+            f.write(f"/INTER/TYPE7/{idx}\n")
+            f.write(f"{name}\n")
+            f.write(f"{slave_id} {master_id} {stiff} {gap} {igap}\n")
+        else:
+            f.write(f"/INTER/TYPE2/{idx}\n")
+            f.write(f"{name}\n")
+            f.write(f"{slave_id} {master_id}\n")
+
+        f.write("/FRICTION\n")
+        f.write(f"{fric}\n")
+
+        f.write(f"/GRNOD/NODE/{slave_id}\n")
+        f.write(f"{name}_slave\n")
+        for nid in s_nodes:
+            f.write(f"{nid:10d}\n")
+
+        f.write(f"/GRNOD/NODE/{master_id}\n")
+        f.write(f"{name}_master\n")
+        for nid in m_nodes:
+            f.write(f"{nid:10d}\n")
+
+
 def write_starter(
     nodes: Dict[int, List[float]],
     elements: List[Tuple[int, int, List[int]]],
@@ -353,39 +394,7 @@ def write_starter(
                     f.write(f"{nid:10d}\n")
 
         if interfaces:
-            for idx, inter in enumerate(interfaces, start=1):
-                itype = inter.get("type", "TYPE2").upper()
-                s_nodes = inter.get("slave", [])
-                m_nodes = inter.get("master", [])
-                name = inter.get("name", f"INTER_{idx}")
-                fric = inter.get("fric", 0.0)
-                slave_id = 200 + idx
-                master_id = 300 + idx
-
-                if itype == "TYPE7":
-                    gap = inter.get("gap", 0.0)
-                    stif = inter.get("stiff", 0.0)
-                    igap = inter.get("igap", 0)
-                    f.write(f"/INTER/TYPE7/{idx}\n")
-                    f.write(f"{name}\n")
-                    f.write(f"{slave_id} {master_id} {stif} {gap} {igap}\n")
-                    f.write("/FRICTION\n")
-                    f.write(f"{fric}\n")
-                else:
-                    f.write(f"/INTER/TYPE2/{idx}\n")
-                    f.write(f"{name}\n")
-                    f.write(f"{slave_id} {master_id}\n")
-                    f.write("/FRICTION\n")
-                    f.write(f"{fric}\n")
-
-                f.write(f"/GRNOD/NODE/{slave_id}\n")
-                f.write(f"{name}_slave\n")
-                for nid in s_nodes:
-                    f.write(f"{nid:10d}\n")
-                f.write(f"/GRNOD/NODE/{master_id}\n")
-                f.write(f"{name}_master\n")
-                for nid in m_nodes:
-                    f.write(f"{nid:10d}\n")
+            _write_interfaces(f, interfaces)
 
         if rbody:
             for idx, rb in enumerate(rbody, start=1):
@@ -1012,39 +1021,7 @@ def write_rad(
                     f.write(f"{nid:10d}\n")
 
         if interfaces:
-            for idx, inter in enumerate(interfaces, start=1):
-                itype = inter.get("type", "TYPE2").upper()
-                s_nodes = inter.get("slave", [])
-                m_nodes = inter.get("master", [])
-                name = inter.get("name", f"INTER_{idx}")
-                fric = inter.get("fric", 0.0)
-                slave_id = 200 + idx
-                master_id = 300 + idx
-
-                if itype == "TYPE7":
-                    gap = inter.get("gap", 0.0)
-                    stif = inter.get("stiff", 0.0)
-                    igap = inter.get("igap", 0)
-                    f.write(f"/INTER/TYPE7/{idx}\n")
-                    f.write(f"{name}\n")
-                    f.write(f"{slave_id} {master_id} {stif} {gap} {igap}\n")
-                    f.write("/FRICTION\n")
-                    f.write(f"{fric}\n")
-                else:
-                    f.write(f"/INTER/TYPE2/{idx}\n")
-                    f.write(f"{name}\n")
-                    f.write(f"{slave_id} {master_id}\n")
-                    f.write("/FRICTION\n")
-                    f.write(f"{fric}\n")
-
-                f.write(f"/GRNOD/NODE/{slave_id}\n")
-                f.write(f"{name}_slave\n")
-                for nid in s_nodes:
-                    f.write(f"{nid:10d}\n")
-                f.write(f"/GRNOD/NODE/{master_id}\n")
-                f.write(f"{name}_master\n")
-                for nid in m_nodes:
-                    f.write(f"{nid:10d}\n")
+            _write_interfaces(f, interfaces)
 
         # 5. RIGID CONNECTORS
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -180,6 +180,9 @@ def test_write_rad_with_type7_contact(tmp_path):
     txt = rad.read_text()
     assert '/INTER/TYPE7/1' in txt
     assert '/FRICTION' in txt
+    for line in txt.splitlines():
+        if line.startswith('/INTER/TYPE7'):
+            assert not line.startswith(' ')
 
 
 def test_write_rad_with_type2_contact(tmp_path):
@@ -196,6 +199,9 @@ def test_write_rad_with_type2_contact(tmp_path):
     txt = rad.read_text()
     assert '/INTER/TYPE2/1' in txt
     assert '/FRICTION' in txt
+    for line in txt.splitlines():
+        if line.startswith('/INTER/TYPE2'):
+            assert not line.startswith(' ')
 
 
 


### PR DESCRIPTION
## Summary
- centralize `/INTER` block creation in a helper
- ensure interface lines have no indentation
- test for properly written contact blocks

## Testing
- `pytest tests/test_basic.py::test_write_rad_with_type7_contact tests/test_basic.py::test_write_rad_with_type2_contact -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed9e40dc883279e1daccaec32ceef