### PR TITLE
Fix unit system codes in starter generation

### DIFF
--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -258,8 +258,8 @@ def write_starter(
         f.write("/BEGIN\n")
         f.write(f"{runname}\n")
         f.write("     2024    0\n")
-        f.write("     kg      mm      ms\n")
-        f.write("     kg      mm      ms\n")
+        f.write("     1       2       3\n")
+        f.write("     1       2       3\n")
 
         def write_law1(mid: int, name: str, rho: float, e: float, nu: float) -> None:
             f.write(f"/MAT/LAW1/{mid}\n")
@@ -817,8 +817,8 @@ def write_rad(
         f.write("/BEGIN\n")
         f.write(f"{runname}\n")
         f.write("     2024         0\n")
-        f.write("                  kg                  mm                   s\n")
-        f.write("                  kg                  mm                   s\n")
+        f.write("                  1                   2                   3\n")
+        f.write("                  1                   2                   3\n")
 
         if include_run:
             # General printout frequency


### PR DESCRIPTION
## Summary
- use numeric unit codes instead of literal `kg mm ms`
- keep unit codes consistent for both starter and general RAD writer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ee3d502c4832793b34306e7648cf6