### PR TITLE
Use literal units in starter header

### DIFF
--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -261,9 +261,8 @@ def write_starter(
         f.write("#RADIOSS STARTER\n")
         f.write("/BEGIN\n")
         f.write(f"{runname}\n")
-        f.write("     2024    0\n")
-        f.write("     1       2       3\n")
-        f.write("     1       2       3\n")
+        f.write("     kg      mm      ms\n")
+        f.write("     kg      mm      ms\n")
 
         def write_law1(mid: int, name: str, rho: float, e: float, nu: float) -> None:
             f.write(f"/MAT/LAW1/{mid}\n")
@@ -820,9 +819,8 @@ def write_rad(
         f.write("#RADIOSS STARTER\n")
         f.write("/BEGIN\n")
         f.write(f"{runname}\n")
-        f.write("     2024         0\n")
-        f.write("                  1                   2                   3\n")
-        f.write("                  1                   2                   3\n")
+        f.write("     kg      mm      ms\n")
+        f.write("     kg      mm      ms\n")
 
         if include_run:
             # General printout frequency

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -73,6 +73,7 @@ def test_write_rad(tmp_path):
     assert '/BEGIN' in content
     assert '/END' in content
     assert '100000.0' in content
+    assert 'kg      mm      ms' in content
 
     eng_txt = engine.read_text()
     assert '/RUN/demo/1' in eng_txt


### PR DESCRIPTION
## Summary
- output units `kg mm ms` rather than numeric codes
- check for unit text in basic starter file test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ee7c8ae588327aa31d03a1f64f31b