### PR TITLE
Fix BCS node-set usage

### DIFF
--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -424,7 +424,13 @@ def write_starter(
             for idx, bc in enumerate(boundary_conditions, start=1):
                 bc_type = str(bc.get("type", "BCS")).upper()
                 name = bc.get("name", f"BC_{idx}")
-                nodes_bc = bc.get("nodes", [])
+                nodes_bc = bc.get("nodes")
+                if nodes_bc is None:
+                    set_name = bc.get("set")
+                    if set_name and node_sets:
+                        nodes_bc = node_sets.get(set_name, [])
+                    else:
+                        nodes_bc = []
                 gid = 100 + idx
 
                 f.write(f"/GRNOD/NODE/{gid}\n")
@@ -1040,7 +1046,13 @@ def write_rad(
             for idx, bc in enumerate(boundary_conditions, start=1):
                 bc_type = str(bc.get("type", "BCS")).upper()
                 name = bc.get("name", f"BC_{idx}")
-                nodes_bc = bc.get("nodes", [])
+                nodes_bc = bc.get("nodes")
+                if nodes_bc is None:
+                    set_name = bc.get("set")
+                    if set_name and node_sets:
+                        nodes_bc = node_sets.get(set_name, [])
+                    else:
+                        nodes_bc = []
                 gid = 100 + idx
 
                 if bc_type == "BCS":

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1004,11 +1004,10 @@ if file_path:
                 bc_data.update({"dir": int(bc_dir), "value": float(bc_val)})
 
             if st.button("Añadir BC") and bc_set:
-                node_list = all_node_sets.get(bc_set, [])
                 entry = {
                     "name": bc_name,
                     "type": bc_type,
-                    "nodes": node_list,
+                    "set": bc_set,
                 }
                 entry.update(bc_data)
                 st.session_state["bcs"].append(entry)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -136,6 +136,22 @@ def test_write_rad_with_bc(tmp_path):
     assert 'fixed' in txt
 
 
+def test_write_rad_with_bc_set(tmp_path):
+    nodes, elements, node_sets, *_ = parse_cdb(DATA)
+    rad = tmp_path / 'bc_set_0000.rad'
+    bc = [{
+        'name': 'fixed',
+        'tra': '111',
+        'rot': '111',
+        'set': 'SUFACE_BALL'
+    }]
+    write_starter(nodes, elements, str(rad), node_sets=node_sets, boundary_conditions=bc)
+    txt = rad.read_text()
+    assert '/BCS/1' in txt
+    first_node = node_sets['SUFACE_BALL'][0]
+    assert str(first_node) in txt
+
+
 def test_write_rad_with_prescribed(tmp_path):
     nodes, elements, *_ = parse_cdb(DATA)
     rad = tmp_path / 'prescribed_0000.rad'


### PR DESCRIPTION
## Summary
- ensure /BCS uses current node set from dashboard
- store selected set name when adding BCs
- resolve nodes from set during starter generation
- test new set-based BC workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ef3e7c5748327a89368414c22f9cc