### PR TITLE
Fix /BEGIN formatting

### DIFF
--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -261,7 +261,7 @@ def write_starter(
         f.write("#RADIOSS STARTER\n")
         f.write("/BEGIN\n")
         f.write(f"{runname}\n")
-        f.write("        2024         0\n")
+        f.write("        2024\n")
         f.write("                  1                  2                  3\n")
         f.write("                  1                  2                  3\n")
 
@@ -820,7 +820,7 @@ def write_rad(
         f.write("#RADIOSS STARTER\n")
         f.write("/BEGIN\n")
         f.write(f"{runname}\n")
-        f.write("        2024         0\n")
+        f.write("        2024\n")
         f.write("                  1                  2                  3\n")
         f.write("                  1                  2                  3\n")
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -73,7 +73,8 @@ def test_write_rad(tmp_path):
     assert '/BEGIN' in content
     assert '/END' in content
     assert '100000.0' in content
-    assert '2024         0' in content
+    assert '2024         0' not in content
+    assert '2024' in content
     assert '1                  2                  3' in content
 
     eng_txt = engine.read_text()


### PR DESCRIPTION
## Summary
- ensure writer outputs full `/BEGIN` block with numeric units only
- adjust unit tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ef22cc3588327b4f5f7939efca3a7