### PR TITLE
Add SI units option for /BEGIN card

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1502,6 +1502,7 @@ if file_path:
                         materials=materials if use_cdb_mats else None,
                         extra_materials=extra,
                         runname=runname,
+                        unit_sys=unit_sel,
 
                         boundary_conditions=st.session_state.get("bcs"),
                         interfaces=st.session_state.get("interfaces"),

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -431,5 +431,22 @@ def test_write_rad_with_solid_prop(tmp_path):
     assert nums2[1] == '1.5'
 
 
+def test_write_starter_si_units(tmp_path):
+    nodes, elements, node_sets, elem_sets, materials = parse_cdb(DATA)
+    rad = tmp_path / 'si_units_0000.rad'
+    write_starter(
+        nodes,
+        elements,
+        str(rad),
+        node_sets=node_sets,
+        elem_sets=elem_sets,
+        materials=materials,
+        unit_sys="SI",
+    )
+    txt = rad.read_text()
+    assert '2017         0' in txt
+    assert 'kg                  mm                  ms' in txt
+
+
 
 


### PR DESCRIPTION
## Summary
- allow writer_rad to emit SI-specific `/BEGIN` block
- propagate `unit_sys` option through dashboard to writer
- verify new behavior with a unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685efb1f11a883278d569dbef5b7124d