### PR TITLE
Fix BC group IDs

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -150,8 +150,7 @@ def test_write_rad_with_bc_set(tmp_path):
     write_starter(nodes, elements, str(rad), node_sets=node_sets, boundary_conditions=bc)
     txt = rad.read_text()
     assert '/BCS/1' in txt
-    first_node = node_sets['SUFACE_BALL'][0]
-    assert str(first_node) in txt
+    assert '/GRNOD/NODE/1' not in txt
 
 
 def test_write_rad_with_prescribed(tmp_path):


### PR DESCRIPTION
## Summary
- reuse node set IDs from `mesh.inc` when writing boundary conditions
- adjust `test_write_rad_with_bc_set` accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f05676a9c83279f659c215b07ec7e