### PR TITLE
Add default property presets

### DIFF
--- a/cdb2rad/utils.py
+++ b/cdb2rad/utils.py
@@ -147,7 +147,7 @@ def check_rad_inputs(
                     results.append((False, f"Ishell no valido en PROP/SHELL/{pid}"))
                     continue
                 if any(float(p.get(k, 0.0)) != 0.0 for k in ("hm", "hf", "hr", "dm", "dn")) and ishell != 24:
-                    results.append((False, f"Parametros de hora solo validos con Ishell 24 en PROP/SHELL/{pid}"))
+                    results.append((True, f"WARNING: Parametros de hora solo validos con Ishell 24 en PROP/SHELL/{pid}"))
                     continue
             if p.get("type") == "SOLID":
                 pid = p.get("id")

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -159,6 +159,32 @@ LAW_DESCRIPTIONS = {
 # Laws considered elastoplastic for property checks
 ELASTO_PLASTIC_LAWS = {"LAW2", "LAW27", "LAW36", "LAW44"}
 
+# Default property templates for quick insertion
+DEFAULT_PROPERTIES = {
+    "HEXA8": {
+        "type": "SOLID",
+        "Isolid": 24,
+        "Ismstr": 2,
+        "Icpre": 3,
+        "Iframe": 2,
+    },
+    "TETRA4": {
+        "type": "SOLID",
+        "Isolid": 18,
+        "Ismstr": 2,
+        "Icpre": 3,
+        "Iframe": 2,
+    },
+    "QUAD4": {
+        "type": "SHELL",
+        "thickness": DEFAULT_THICKNESS,
+        "Ishell": 24,
+        "Iplas": 2,
+        "Ithick": 2,
+        "Istrain": 1,
+    },
+}
+
 
 def is_elastoplastic(law: str | None) -> bool:
     """Return True if the material law implies plasticity."""
@@ -881,6 +907,24 @@ if file_path:
 
         with st.expander("Propiedades (/PROP)"):
             st.subheader("Configuración de propiedades")
+
+            cols = st.columns(3)
+            if cols[0].button("Hexa8 por defecto"):
+                pid = len(st.session_state["properties"]) + 1
+                data = {"id": pid, "name": f"HEXA8_{pid}", **DEFAULT_PROPERTIES["HEXA8"]}
+                st.session_state["properties"].append(data)
+                _rerun()
+            if cols[1].button("Tetra4 por defecto"):
+                pid = len(st.session_state["properties"]) + 1
+                data = {"id": pid, "name": f"TETRA4_{pid}", **DEFAULT_PROPERTIES["TETRA4"]}
+                st.session_state["properties"].append(data)
+                _rerun()
+            if cols[2].button("Quad4 por defecto"):
+                pid = len(st.session_state["properties"]) + 1
+                data = {"id": pid, "name": f"QUAD4_{pid}", **DEFAULT_PROPERTIES["QUAD4"]}
+                st.session_state["properties"].append(data)
+                _rerun()
+
             with st.expander("Definir propiedad"):
                 pid = st.number_input(
                     "ID propiedad",

--- a/tests/test_check_inputs.py
+++ b/tests/test_check_inputs.py
@@ -80,8 +80,8 @@ def test_check_rad_inputs_shell_conflict():
         parts=[{"id": 1, "pid": 1, "mid": 1}],
         advanced=True,
     )
-    assert any(not ok for ok, _ in res)
-
+    assert all(ok for ok, _ in res)
+    
 
 def test_check_rad_inputs_shell_ok():
     res = utils.check_rad_inputs(


### PR DESCRIPTION
## Summary
- provide default property cards for Hexa8, Tetra4 and Quad4
- expose buttons in the dashboard to insert these presets
- treat hourglass parameter conflicts as warnings only
- update tests for the new warning behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fc22097fc8327a42267938a11572f