### PR TITLE
Ignore UMID/UVID material cards

### DIFF
--- a/cdb2rad/parser.py
+++ b/cdb2rad/parser.py
@@ -143,6 +143,9 @@ def parse_cdb(filepath: str) -> Tuple[
                 try:
                     mid = int(parts[2])
                     prop = parts[3]
+                    if prop.strip().upper() in {"UMID", "UVID"}:
+                        i += 1
+                        continue
                     vals = [float(v) for v in parts[6:] if v]
                     if vals:
                         materials.setdefault(mid, {})[prop] = vals[0]

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -72,7 +72,7 @@ def test_write_rad(tmp_path):
     assert content.startswith('#RADIOSS STARTER')
     assert '/BEGIN' in content
     assert '/END' in content
-    assert '100000.0' in content
+    assert '200000.0' in content
     assert '2024         0' not in content
     assert '2024' in content
     assert '1                  2                  3' in content


### PR DESCRIPTION
## Summary
- skip UMID and UVID material records when parsing CDB files
- adjust unit test to match updated starter contents

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fd31703908327879fc84de9aaf4ee