### PR TITLE
Improve element set info and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,30 @@ ejemplos de la documentación.
 
 ## Salida generada
 
- - ``mesh.inc``: definición de nodos y elementos.
- - ``model_0000.rad``: fichero de inicio con propiedades, material y BCs.
+- ``mesh.inc``: definición de nodos y elementos.
+- ``model_0000.rad``: fichero de inicio con propiedades, material y BCs.
+
+### Tipos de elemento admitidos
+
+El archivo ``cdb2rad/mapping.json`` define la correspondencia básica entre
+los ``ETYP`` de Ansys y las palabras clave de Radioss utilizadas en
+``mesh.inc``. Los valores incluidos por defecto son:
+
+| ETYP | Nombre Ansys  | Radioss |
+|-----:|---------------|---------|
+| 1    | SOLID185      | /BRICK  |
+| 2    | SHELL181      | /SHELL  |
+| 4    | SHELL63       | /SHELL  |
+| 45   | SHELL45       | /SHELL  |
+| 181  | SHELL181      | /SHELL  |
+| 182  | SHELL281      | /SHELL  |
+| 185  | SOLID185      | /BRICK  |
+| 186  | SOLID186      | /BRICK  |
+| 187  | SOLID187      | /TETRA  |
+
+Si se encuentra un ``ETYP`` no contemplado en la tabla, el número de nodos
+del elemento se utiliza para decidir entre ``/SHELL``, ``/BRICK`` o ``/TETRA``.
+
 
 ## Instalación de dependencias
 

--- a/cdb2rad/__init__.py
+++ b/cdb2rad/__init__.py
@@ -3,7 +3,7 @@
 from .parser import parse_cdb
 from .writer_inc import write_mesh_inc
 from .writer_rad import write_rad, write_starter, write_engine
-from .utils import element_summary
+from .utils import element_summary, element_set_types
 from .remote import add_remote_point, next_free_node_id
 from .material_defaults import apply_default_materials
 
@@ -14,6 +14,7 @@ __all__ = [
     "write_starter",
     "write_engine",
     "element_summary",
+    "element_set_types",
     "apply_default_materials",
     "add_remote_point",
     "next_free_node_id",

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -693,16 +693,18 @@ if file_path:
         elem_id_map = {n: i for i, n in enumerate(all_elem_sets.keys(), start=1)}
 
         with st.expander("Grupos importados"):
-            rows = (
-                [
-                    {"Nombre": n, "ID": idx, "Tipo": "NODOS"}
-                    for n, idx in node_id_map.items()
-                ]
-                + [
-                    {"Nombre": n, "ID": idx, "Tipo": "ELEMENTOS"}
-                    for n, idx in elem_id_map.items()
-                ]
-            )
+            from cdb2rad.utils import element_set_types
+
+            set_info = element_set_types(elements, all_elem_sets)
+            rows = [
+                {"Nombre": n, "ID": idx, "Tipo": "NODOS", "Elementos": ""}
+                for n, idx in node_id_map.items()
+            ]
+            for n, idx in elem_id_map.items():
+                info = set_info.get(n, {})
+                desc = ", ".join(f"{k}:{v}" for k, v in info.items()) if info else ""
+                rows.append({"Nombre": n, "ID": idx, "Tipo": "ELEMENTOS", "Elementos": desc})
+
             if rows:
                 st.table(rows)
             else:


### PR DESCRIPTION
## Summary
- expose new `element_set_types` helper in utils and public API
- show element types for each set in the dashboard
- document default ETYP to Radioss mapping in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fd9c1148883278dc5fde2fa90e01b