### PR TITLE
Update RAD version to 2022

### DIFF
--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -40,6 +40,9 @@ DEFAULT_BRICK_ANIM_DT = None
 DEFAULT_HISNODA_DT = None
 DEFAULT_RFILE_DT = None
 
+# Default Radioss version for the /VERS card and /BEGIN block
+DEFAULT_RAD_VERSION = 2022
+
 
 def _merge_materials(
     base: Dict[int, Dict[str, float]] | None,
@@ -186,7 +189,7 @@ def _write_begin(f, runname: str, unit_sys: str | None) -> None:
         f.write("                  kg                  mm                  ms\n")
         f.write("                  kg                  mm                  ms\n")
     else:
-        f.write("        2024\n")
+        f.write(f"        {DEFAULT_RAD_VERSION}\n")
         f.write("                  1                  2                  3\n")
         f.write("                  1                  2                  3\n")
 
@@ -713,7 +716,7 @@ def write_engine(
         if tfile_dt is not None:
             f.write("/TFILE/0\n")
             f.write(f"{tfile_dt}\n")
-        f.write("/VERS/2024\n")
+        f.write(f"/VERS/{DEFAULT_RAD_VERSION}\n")
         if dt_ratio is not None:
             f.write("/DT/NODA/CST/0\n")
             f.write(f"{dt_ratio} 0 0\n")
@@ -889,7 +892,7 @@ def write_rad(
             if tfile_dt is not None:
                 f.write("/TFILE/0\n")
                 f.write(f"{tfile_dt}\n")
-            f.write("/VERS/2024\n")
+            f.write(f"/VERS/{DEFAULT_RAD_VERSION}\n")
             if dt_ratio is not None:
                 f.write("/DT/NODA/CST/0\n")
                 f.write(f"{dt_ratio} 0 0\n")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -73,8 +73,8 @@ def test_write_rad(tmp_path):
     assert '/BEGIN' in content
     assert '/END' in content
     assert '200000.0' in content
-    assert '2024         0' not in content
-    assert '2024' in content
+    assert '2022         0' not in content
+    assert '2022' in content
     assert '1                  2                  3' in content
 
     eng_txt = engine.read_text()


### PR DESCRIPTION
## Summary
- default Radioss version for generated `.rad` files is now 2022
- update tests expecting 2022

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68604448e8d08327824c7d67f5c451a8