### PR TITLE
Add mandatory integer field guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ This repository implements a lightweight **translator between Ansys `.cdb` files
 The agent’s task is to help maintain and extend a Python program that takes as input a `.cdb` file exported from Ansys Mechanical or MAPDL, and produces:
 
 For all keyword formats and examples, consult the [Altair Radioss 2022 Reference Guide](https://2022.help.altair.com/2022/simulation/pdfs/radopen/AltairRadioss_2022_ReferenceGuide.pdf), which is the primary source for this project.
+**Priority**: All integer fields must be written with every mandatory line and parameter exactly as specified in the 2022 documentation (<https://help.altair.com/hwsolvers/rad/index.htm>).
 
 1. A **Radioss input mesh file** (`mesh.inc`) containing:
    - `/NODE`, `/SHELL`, `/BRICK` definitions

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ ejemplos de la documentación.
 
 - ``mesh.inc``: definición de nodos y elementos.
 - ``model_0000.rad``: fichero de inicio con propiedades, material y BCs.
+## ⚠️ Orden obligatoria
+
+Todos los campos enteros de cada tarjeta deben escribirse con sus lineas completas y parametros obligatorios. Consulta siempre la [documentacion de Radioss 2022](https://help.altair.com/hwsolvers/rad/index.htm) para verificar la sintaxis.
+
 
 ### Tipos de elemento admitidos
 


### PR DESCRIPTION
## Summary
- mandate integer fields in README
- prioritize integer fields in AGENTS

## Testing
- `pytest -q` *(fails: AssertionError in test_write_rad and test_write_starter_si_units)*

------
https://chatgpt.com/codex/tasks/task_e_68604de6e958832787e335a6b54df17e