### PR TITLE
Improve preview helpers

### DIFF
--- a/cdb2rad/rad_preview.py
+++ b/cdb2rad/rad_preview.py
@@ -37,7 +37,7 @@ def _extract_block(text: str, start: str) -> str:
                 out.append("...")
                 break
             out.append(ln)
-            if ln.startswith("/") and ln != start and not ln.startswith("#"):
+            if ln.startswith("/") and not ln.startswith(start) and not ln.startswith("#"):
                 break
     return "\n".join(out)
 
@@ -76,7 +76,7 @@ def preview_part(part: Dict[str, Any]) -> str:
         buf,
         parts=[part],
         include_inc=False,
-        default_material=False,
+        default_material=True,
     )
     return _extract_block(buf.getvalue(), f"/PART/{part.get('id',1)}")
 

--- a/tests/test_rad_preview.py
+++ b/tests/test_rad_preview.py
@@ -1,0 +1,15 @@
+from cdb2rad import rad_preview
+
+def test_extract_block_material():
+    sample = """/MAT/LAW1/1\nSteel\n# RHO\n7800\n# E Nu\n210000 0.3\n/END\n"""
+    out = rad_preview._extract_block(sample, "/MAT/")
+    lines = out.splitlines()
+    assert lines[0].startswith("/MAT/LAW1/1")
+    assert len(lines) > 2
+
+
+def test_preview_part_no_material():
+    part = {"id": 1, "name": "P1", "pid": 1, "mid": 1}
+    txt = rad_preview.preview_part(part)
+    assert "/PART/1" in txt
+    assert "P1" in txt


### PR DESCRIPTION
## Summary
- fix block extraction logic
- allow part previews without explicit material
- add regression tests for preview utilities

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68608ce26e248327a0cb8c41fc885040