### PR TITLE
Fix ADYREL preview in dashboard

### DIFF
--- a/cdb2rad/rad_preview.py
+++ b/cdb2rad/rad_preview.py
@@ -188,7 +188,12 @@ def preview_subset(name: str, ids: List[int], idx: int) -> str:
 
 def preview_control(settings: Dict[str, Any]) -> str:
     buf = StringIO()
-    write_engine(buf, **settings)
+    ctrl_args = dict(settings)
+    if "adyrel_start" in ctrl_args or "adyrel_stop" in ctrl_args:
+        start = ctrl_args.pop("adyrel_start", None)
+        stop = ctrl_args.pop("adyrel_stop", None)
+        ctrl_args["adyrel"] = (start, stop)
+    write_engine(buf, **ctrl_args)
     text = buf.getvalue()
     lines = text.splitlines()
     return "\n".join(lines[1:])


### PR DESCRIPTION
## Summary
- adapt `preview_control` to accept session state dictionary
- handle `adyrel_start`/`adyrel_stop` by passing as tuple `adyrel`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68610963b7c8832784f1bb9f2d0fb3ca