### PR TITLE
Fix dashboard material preview with FAIL blocks

### DIFF
--- a/cdb2rad/rad_preview.py
+++ b/cdb2rad/rad_preview.py
@@ -63,6 +63,7 @@ def _extract_block(text: str, start: str) -> str:
         if (
             ln.startswith("/")
             and not ln.startswith(start)
+            and not ln.startswith("/FAIL")
             and not ln.startswith("#")
         ):
             break

--- a/tests/test_rad_preview.py
+++ b/tests/test_rad_preview.py
@@ -33,3 +33,19 @@ def test_preview_bc_types():
     assert "/BOUNDARY/PRESCRIBED_MOTION/1" in txt_mov
     assert "Move" in txt_mov
 
+
+def test_preview_material_with_fail():
+    mat = {
+        "id": 1,
+        "LAW": "LAW1",
+        "EX": 210000,
+        "NUXY": 0.3,
+        "DENS": 7800.0,
+        "FAIL": {"TYPE": "JOHNSON", "D1": -0.09},
+    }
+    txt = rad_preview.preview_material(mat)
+    lines = txt.splitlines()
+    assert any(l.startswith("/FAIL/JOHNSON/1") for l in lines)
+    fail_idx = next(i for i, l in enumerate(lines) if l.startswith("/FAIL/JOHNSON/1"))
+    assert fail_idx + 1 < len(lines)
+


### PR DESCRIPTION
## Summary
- ensure preview_material keeps `/FAIL` blocks when extracting material cards
- test preview for materials with FAIL definitions

## Testing
- `pytest -q`
- `pytest tests/test_rad_preview.py::test_preview_material_with_fail -q`

------
https://chatgpt.com/codex/tasks/task_e_68610a9fa474832785cea3878845b1c7