### PR TITLE
Preview remote point card in dashboard

### DIFF
--- a/cdb2rad/rad_preview.py
+++ b/cdb2rad/rad_preview.py
@@ -203,6 +203,13 @@ def preview_gravity(data: Dict[str, Any]) -> str:
     return _extract_block(buf.getvalue(), "/GRAV")
 
 
+def preview_remote_point(rp: Dict[str, Any]) -> str:
+    """Return ``/NODE`` lines for a remote point preview."""
+    nid = int(rp.get("id", 0))
+    x, y, z = rp.get("coords", (0.0, 0.0, 0.0))
+    return f"/NODE\n{nid:10d}{x:15.6f}{y:15.6f}{z:15.6f}"
+
+
 def preview_subset(name: str, ids: List[int], idx: int) -> str:
     buf = StringIO()
     write_starter(

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1212,7 +1212,7 @@ if file_path:
             for i, rp in enumerate(st.session_state.get("remote_points", [])):
                 cols = st.columns([4, 1])
                 with cols[0]:
-                    st.write(f"ID {rp['id']} → {rp['coords']}")
+                    st.code(rad_preview.preview_remote_point(rp))
                 with cols[1]:
                     if st.button("Eliminar", key=f"del_rp_{i}"):
                         st.session_state["remote_points"].pop(i)

--- a/tests/test_rad_preview.py
+++ b/tests/test_rad_preview.py
@@ -49,3 +49,12 @@ def test_preview_material_with_fail():
     fail_idx = next(i for i, l in enumerate(lines) if l.startswith("/FAIL/JOHNSON/1"))
     assert fail_idx + 1 < len(lines)
 
+
+def test_preview_remote_point():
+    rp = {"id": 10, "coords": (1.0, 2.0, 3.0)}
+    txt = rad_preview.preview_remote_point(rp)
+    lines = txt.splitlines()
+    assert lines[0] == "/NODE"
+    assert "10" in lines[1]
+    assert "1.000000" in lines[1]
+


### PR DESCRIPTION
## Summary
- add preview_remote_point helper to `rad_preview`
- show each remote point as `/NODE` card in the dashboard
- test remote point preview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68610cee120c832793f4a3ad496faf8f