### PR TITLE
Improve rad writer tests

### DIFF
--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -235,7 +235,7 @@ def write_starter(
 
     ``unit_sys`` can be set to ``"SI"`` to output the ``/BEGIN`` card with
     kilogram--millimeter--millisecond units as used in legacy examples.
-    Set ``auto_subsets=False`` to avoid generar automatically ``/SUBSET`` cards
+    Set ``auto_subsets=False`` to avoid generating ``/SUBSET`` cards
     from element groups referenced in ``parts``.
     """
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,7 +1,8 @@
 import os
 from cdb2rad.parser import parse_cdb
 from cdb2rad.writer_inc import write_mesh_inc
-from cdb2rad.writer_rad import write_starter, write_engine
+from cdb2rad.writer_rad import write_starter, write_engine, write_rad
+from cdb2rad.rad_validator import validate_rad_format
 from cdb2rad.utils import element_summary, element_set_etypes
 
 DATA = os.path.join(os.path.dirname(__file__), '..', 'data', 'model.cdb')
@@ -451,6 +452,25 @@ def test_write_starter_si_units(tmp_path):
     txt = rad.read_text()
     assert '2017         0' in txt
     assert 'kg                  mm                  ms' in txt
+
+
+def test_write_rad_combined(tmp_path):
+    nodes, elements, node_sets, elem_sets, materials = parse_cdb(DATA)
+    rad = tmp_path / 'combined.rad'
+    write_rad(
+        nodes,
+        elements,
+        str(rad),
+        node_sets=node_sets,
+        elem_sets=elem_sets,
+        materials=materials,
+        t_end=0.02,
+        print_n=-100,
+    )
+    txt = rad.read_text()
+    assert '/RUN/' in txt
+    assert '/END' in txt
+    validate_rad_format(str(rad))
 
 
 def test_element_set_etypes():


### PR DESCRIPTION
## Summary
- clarify docstring about subset auto generation
- cover `write_rad` helper in test suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686124c0a1e88327bee614af6964709a