### PR TITLE
Downgrade unused subset check to warning

### DIFF
--- a/cdb2rad/utils.py
+++ b/cdb2rad/utils.py
@@ -217,7 +217,8 @@ def check_rad_inputs(
         used = {pt.get("set") for pt in parts or [] if pt.get("set")}
         unused = [name for name in subsets.keys() if name not in used]
         for sub in unused:
-            results.append((False, f"Subset sin uso: {sub}"))
+            # Unused subsets should not fail the check; report as a warning
+            results.append((True, f"WARNING: Subset sin uso: {sub}"))
 
     # 6. Node set existence
     if bcs and node_sets and nodes:


### PR DESCRIPTION
## Summary
- treat unused subset detection as a warning in `check_rad_inputs`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68612577a1c483278a7bcc5fec3336b1