### PR TITLE
Fix /BEGIN version handling

### DIFF
--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -192,14 +192,13 @@ def _write_begin(f, runname: str, unit_sys: str | None) -> None:
     f.write("/BEGIN\n")
     f.write(f"{runname}\n")
     if unit_sys == "SI":
-        f.write("      2017         0\n")
+        f.write(f"      {DEFAULT_RAD_VERSION}         0\n")
         f.write("                  kg                  mm                  ms\n")
         f.write("                  kg                  mm                  ms\n")
     else:
-        f.write("      2024         0\n")
+        f.write(f"      {DEFAULT_RAD_VERSION}         0\n")
         f.write("                  1                  2                  3\n")
         f.write("                  1                  2                  3\n")
-    f.write("# version 2022\n")
 
 def write_starter(
     nodes: Dict[int, List[float]],

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -73,7 +73,7 @@ def test_write_rad(tmp_path):
     assert '/BEGIN' in content
     assert '/END' in content
     assert '200000.0' in content
-    assert '2022         0' not in content
+    assert '2022         0' in content
     assert '2022' in content
     assert '1                  2                  3' in content
 
@@ -450,7 +450,7 @@ def test_write_starter_si_units(tmp_path):
         unit_sys="SI",
     )
     txt = rad.read_text()
-    assert '2017         0' in txt
+    assert '2022         0' in txt
     assert 'kg                  mm                  ms' in txt
 
 


### PR DESCRIPTION
## Summary
- use DEFAULT_RAD_VERSION when writing the /BEGIN card for either unit system
- drop leftover version comment

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68612e20747c8327a1592d8889b9d448