### PR TITLE
Fix NameError in RAD editor defaults

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -130,6 +130,10 @@ from cdb2rad.writer_rad import (
     DEFAULT_STOP_NTH,
     DEFAULT_STOP_NANIM,
     DEFAULT_STOP_NERR,
+    DEFAULT_SHELL_ANIM_DT,
+    DEFAULT_BRICK_ANIM_DT,
+    DEFAULT_HISNODA_DT,
+    DEFAULT_RFILE_DT,
     DEFAULT_THICKNESS,
 )
 from cdb2rad.writer_inc import write_mesh_inc


### PR DESCRIPTION
## Summary
- import missing default constants in `dashboard/app.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861620aab548327b6041644b930a59b