### PR TITLE
Respect checkbox for CDB material inclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ Se incluyen casillas opcionales para **sobrescribir** los archivos
 ``.inc`` o ``.rad`` si ya existen en el directorio de salida.
 - La opción **Incluir materiales del CDB** está desactivada por defecto;
   actívala si deseas copiar al starter los materiales extraídos del `.cdb`.
+  Si permanece desactivada y no se definen materiales de impacto,
+  el archivo resultante no contendrá tarjetas `/MAT`.
 
 
 La pestaña *Generar RAD* también permite definir condiciones de contorno

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -599,6 +599,7 @@ def build_rad_text(
         elem_sets=all_elem_sets,
         materials=materials if use_cdb_mats else None,
         extra_materials=extra,
+        default_material=use_cdb_mats or use_impact,
         runname=runname,
         unit_sys=st.session_state.get("unit_sys", UNIT_OPTIONS[0]),
         boundary_conditions=st.session_state.get("bcs"),
@@ -1832,6 +1833,7 @@ if file_path:
                         elem_sets=all_elem_sets,
                         materials=materials if use_cdb_mats else None,
                         extra_materials=extra,
+                        default_material=use_cdb_mats or use_impact,
                         runname=runname,
                         unit_sys=unit_sel,
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -297,6 +297,14 @@ def test_write_rad_without_include(tmp_path):
     assert '#include' not in content
 
 
+def test_write_rad_no_materials(tmp_path):
+    nodes, elements, *_ = parse_cdb(DATA)
+    rad = tmp_path / 'nomat_0000.rad'
+    write_starter(nodes, elements, str(rad), default_material=False)
+    text = rad.read_text()
+    assert '/MAT/' not in text
+
+
 def test_write_rad_skip_controls(tmp_path):
     nodes, elements, *_ = parse_cdb(DATA)
     starter = tmp_path / 'skip_0000.rad'


### PR DESCRIPTION
## Summary
- ensure starter generation honors the CDB material checkbox
- document that disabling the option removes `/MAT` cards
- test generating a starter without any materials

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686164d51cb483279b1ebe42a09c8838