### PR TITLE
Allow ignoring CDB materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,13 @@ opción ``--skip-include`` se genera el ``.rad`` sin esa referencia:
 python scripts/run_all.py data_files/model.cdb --rad model.rad --skip-include
 ```
 
+Si se desea ignorar completamente los materiales leídos del ``.cdb`` basta con
+añadir ``--no-cdb-materials``:
+
+```bash
+python scripts/run_all.py data_files/model.cdb --rad sin_mats.rad --no-cdb-materials --no-default-material
+```
+
 Para generar un ``.rad`` limpio sin tarjetas de control ni material por defecto
 pueden emplearse las opciones ``--no-run-cards`` y ``--no-default-material``:
 

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -36,6 +36,11 @@ def main() -> None:
         action="store_true",
         help="Do not insert a default material when none are provided",
     )
+    parser.add_argument(
+        "--no-cdb-materials",
+        action="store_true",
+        help="Ignore material definitions extracted from the .cdb file",
+    )
 
     args = parser.parse_args()
 
@@ -53,7 +58,7 @@ def main() -> None:
             args.inc,
             node_sets=node_sets,
             elem_sets=elem_sets,
-            materials=materials,
+            materials=None if args.no_cdb_materials else materials,
         )
     if args.starter:
         write_starter(
@@ -64,7 +69,7 @@ def main() -> None:
             include_inc=not args.skip_include,
             node_sets=node_sets,
             elem_sets=elem_sets,
-            materials=materials,
+            materials=None if args.no_cdb_materials else materials,
             default_material=not args.no_default_material,
         )
     if args.engine:


### PR DESCRIPTION
## Summary
- add `--no-cdb-materials` CLI option to `run_all.py`
- document how to disable materials in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68616aa7d6a08327b386e2072220d46f