### PR TITLE
Add automatic default material when none provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ añadir ``--no-cdb-materials``:
 python scripts/run_all.py data_files/model.cdb --rad sin_mats.rad --no-cdb-materials --no-default-material
 ```
 
+Si se omite ``--no-default-material`` y existen tarjetas ``/PART``, el script
+añade de forma automática un material genérico ``/MAT/LAW1`` para evitar
+errores por IDs no definidos.
+
 Para generar un ``.rad`` limpio sin tarjetas de control ni material por defecto
 pueden emplearse las opciones ``--no-run-cards`` y ``--no-default-material``:
 

--- a/cdb2rad/utils.py
+++ b/cdb2rad/utils.py
@@ -202,13 +202,14 @@ def check_rad_inputs(
 
     # 4. Part references
     if parts:
+        auto_default_mat = use_cdb_mats or use_impact or (not mat_ids and parts)
         for pt in parts:
             pid = int(pt.get("pid", 0))
             mid = int(pt.get("mid", 0))
             if pid not in prop_ids:
                 results.append((False, f"PART {pt.get('id')} referencia PROP {pid} inexistente"))
                 break
-            if mid not in mat_ids:
+            if mid not in mat_ids and not auto_default_mat:
                 results.append((False, f"PART {pt.get('id')} referencia MAT {mid} inexistente"))
                 break
 

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -592,6 +592,10 @@ def build_rad_text(
         adyrel_stop = ctrl.get("adyrel_stop", adyrel_stop)
 
     buf0 = StringIO()
+    use_default_mat = use_cdb_mats or use_impact
+    if not use_default_mat and st.session_state.get("parts"):
+        # Insert a generic LAW1 block when parts exist but no materials
+        use_default_mat = True
     write_starter(
         all_nodes,
         elements,
@@ -602,7 +606,7 @@ def build_rad_text(
         elem_sets=all_elem_sets,
         materials=materials if use_cdb_mats else None,
         extra_materials=extra,
-        default_material=use_cdb_mats or use_impact,
+        default_material=use_default_mat,
         runname=runname,
         unit_sys=st.session_state.get("unit_sys", UNIT_OPTIONS[0]),
         boundary_conditions=st.session_state.get("bcs"),
@@ -1827,6 +1831,9 @@ if file_path:
                 if not include_inc:
                     write_mesh_inc(all_nodes, elements, str(mesh_path), node_sets=all_node_sets)
                 all_elem_sets = {**elem_sets, **st.session_state.get("subsets", {})}
+                use_default_mat = use_cdb_mats or use_impact
+                if not use_default_mat and st.session_state.get("parts"):
+                    use_default_mat = True
                 write_starter(
                         all_nodes,
                         elements,
@@ -1837,7 +1844,7 @@ if file_path:
                         elem_sets=all_elem_sets,
                         materials=materials if use_cdb_mats else None,
                         extra_materials=extra,
-                        default_material=use_cdb_mats or use_impact,
+                        default_material=use_default_mat,
                         runname=runname,
                         unit_sys=unit_sel,
 


### PR DESCRIPTION
## Summary
- ensure the dashboard inserts a generic `/MAT/LAW1` if parts exist but no materials are defined
- adjust input checks to allow this behaviour
- document new default material logic in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686174ae9cb883278f961e40e762096a