### PR TITLE
Add auto part/property generation

### DIFF
--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -240,8 +240,45 @@ def write_starter(
     """
 
     all_mats, mid_map = _merge_materials(materials, extra_materials)
+    if not all_mats and default_material:
+        all_mats = {1: {}}
+        mid_map = {1: 1}
     if all_mats:
         all_mats = apply_default_materials(all_mats)
+
+    if (not properties or not parts) and all_mats:
+        from .utils import element_summary
+        _, kw_counts = element_summary(elements)
+        is_shell = kw_counts.get("SHELL", 0) >= kw_counts.get("BRICK", 0)
+        if not properties:
+            if is_shell:
+                properties = [
+                    {
+                        "id": 1,
+                        "name": "AutoProp",
+                        "type": "SHELL",
+                        "thickness": thickness,
+                    }
+                ]
+            else:
+                properties = [
+                    {
+                        "id": 1,
+                        "name": "AutoProp",
+                        "type": "SOLID",
+                        "Isolid": 24,
+                    }
+                ]
+        if not parts:
+            mat_id = next(iter(all_mats.keys()), 1)
+            parts = [
+                {
+                    "id": 1,
+                    "name": "AutoPart",
+                    "pid": properties[0]["id"],
+                    "mid": mat_id,
+                }
+            ]
 
     if include_inc:
         write_mesh_inc(
@@ -855,8 +892,45 @@ def write_rad(
     """
 
     all_mats, mid_map = _merge_materials(materials, extra_materials)
+    if not all_mats and default_material:
+        all_mats = {1: {}}
+        mid_map = {1: 1}
     if all_mats:
         all_mats = apply_default_materials(all_mats)
+
+    if (not properties or not parts) and all_mats:
+        from .utils import element_summary
+        _, kw_counts = element_summary(elements)
+        is_shell = kw_counts.get("SHELL", 0) >= kw_counts.get("BRICK", 0)
+        if not properties:
+            if is_shell:
+                properties = [
+                    {
+                        "id": 1,
+                        "name": "AutoProp",
+                        "type": "SHELL",
+                        "thickness": thickness,
+                    }
+                ]
+            else:
+                properties = [
+                    {
+                        "id": 1,
+                        "name": "AutoProp",
+                        "type": "SOLID",
+                        "Isolid": 24,
+                    }
+                ]
+        if not parts:
+            mat_id = next(iter(all_mats.keys()), 1)
+            parts = [
+                {
+                    "id": 1,
+                    "name": "AutoPart",
+                    "pid": properties[0]["id"],
+                    "mid": mat_id,
+                }
+            ]
 
     if include_inc:
         write_mesh_inc(

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -305,6 +305,15 @@ def test_write_rad_no_materials(tmp_path):
     assert '/MAT/' not in text
 
 
+def test_write_rad_auto_parts(tmp_path):
+    nodes, elements, _, _, mats = parse_cdb(DATA)
+    rad = tmp_path / 'auto_0000.rad'
+    write_starter(nodes, elements, str(rad), materials=mats)
+    txt = rad.read_text()
+    assert '/PROP/' in txt
+    assert '/PART/1' in txt
+
+
 def test_write_rad_skip_controls(tmp_path):
     nodes, elements, *_ = parse_cdb(DATA)
     starter = tmp_path / 'skip_0000.rad'


### PR DESCRIPTION
## Summary
- automatically add a basic property and part when a material is present
- test default auto parts generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861796307c48327b8b34ae8cff27df1