### PR TITLE
Fix material checkbox keys for dashboard

### DIFF
--- a/cdb2rad/rad_preview.py
+++ b/cdb2rad/rad_preview.py
@@ -73,6 +73,8 @@ def preview_material(mat: Dict[str, Any]) -> str:
         materials={int(mat.get("id", 1)): mat},
         include_inc=False,
         default_material=False,
+        auto_properties=False,
+        auto_parts=False,
     )
     return _extract_block(buf.getvalue(), "/MAT/")
 

--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -229,6 +229,8 @@ def write_starter(
     subsets: Dict[str, List[int]] | None = None,
     auto_subsets: bool = True,
     default_material: bool = True,
+    auto_properties: bool = True,
+    auto_parts: bool = True,
     unit_sys: str | None = None,
 ) -> None:
     """Write a Radioss starter file (``*_0000.rad``).
@@ -236,7 +238,9 @@ def write_starter(
     ``unit_sys`` can be set to ``"SI"`` to output the ``/BEGIN`` card with
     kilogram--millimeter--millisecond units as used in legacy examples.
     Set ``auto_subsets=False`` to avoid generating ``/SUBSET`` cards
-    from element groups referenced in ``parts``.
+    from element groups referenced in ``parts``. ``auto_properties`` and
+    ``auto_parts`` control whether placeholder ``/PROP`` and ``/PART`` cards
+    are inserted when no definitions are provided but materials exist.
     """
 
     all_mats, mid_map = _merge_materials(materials, extra_materials)
@@ -246,11 +250,11 @@ def write_starter(
     if all_mats:
         all_mats = apply_default_materials(all_mats)
 
-    if (not properties or not parts) and all_mats:
-        from .utils import element_summary
-        _, kw_counts = element_summary(elements)
-        is_shell = kw_counts.get("SHELL", 0) >= kw_counts.get("BRICK", 0)
-        if not properties:
+    if all_mats:
+        if auto_properties and not properties:
+            from .utils import element_summary
+            _, kw_counts = element_summary(elements)
+            is_shell = kw_counts.get("SHELL", 0) >= kw_counts.get("BRICK", 0)
             if is_shell:
                 properties = [
                     {
@@ -269,7 +273,8 @@ def write_starter(
                         "Isolid": 24,
                     }
                 ]
-        if not parts:
+
+        if auto_parts and not parts and properties:
             mat_id = next(iter(all_mats.keys()), 1)
             parts = [
                 {
@@ -872,6 +877,8 @@ def write_rad(
     auto_subsets: bool = True,
     include_run: bool = True,
     default_material: bool = True,
+    auto_properties: bool = True,
+    auto_parts: bool = True,
     unit_sys: str | None = None,
 ) -> None:
     """Generate ``model_0000.rad`` with optional solver controls.
@@ -888,7 +895,8 @@ def write_rad(
     provided. ``unit_sys`` behaves like the same argument in
     :func:`write_starter` and customizes the ``/BEGIN`` block. Use
     ``auto_subsets=False`` to skip the automatic creation of ``/SUBSET`` cards
-    from element groups when ``parts`` reference them.
+    from element groups when ``parts`` reference them. ``auto_properties`` and
+    ``auto_parts`` have the same meaning as in :func:`write_starter`.
     """
 
     all_mats, mid_map = _merge_materials(materials, extra_materials)
@@ -898,11 +906,11 @@ def write_rad(
     if all_mats:
         all_mats = apply_default_materials(all_mats)
 
-    if (not properties or not parts) and all_mats:
-        from .utils import element_summary
-        _, kw_counts = element_summary(elements)
-        is_shell = kw_counts.get("SHELL", 0) >= kw_counts.get("BRICK", 0)
-        if not properties:
+    if all_mats:
+        if auto_properties and not properties:
+            from .utils import element_summary
+            _, kw_counts = element_summary(elements)
+            is_shell = kw_counts.get("SHELL", 0) >= kw_counts.get("BRICK", 0)
             if is_shell:
                 properties = [
                     {
@@ -921,7 +929,8 @@ def write_rad(
                         "Isolid": 24,
                     }
                 ]
-        if not parts:
+
+        if auto_parts and not parts and properties:
             mat_id = next(iter(all_mats.keys()), 1)
             parts = [
                 {

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -529,8 +529,8 @@ def build_rad_text(
             part_node_sets[part["name"]] = sorted(nodes_in_part)
     all_node_sets.update(part_node_sets)
 
-    use_cdb_mats = st.session_state.get("Incluir materiales del CDB", False)
-    use_impact = st.session_state.get("Incluir materiales de impacto", False)
+    use_cdb_mats = st.session_state.get("use_cdb_mats", False)
+    use_impact = st.session_state.get("use_impact", False)
     include_inc = st.session_state.get("include_inc_rad", True)
 
     extra = None
@@ -620,6 +620,7 @@ def build_rad_text(
         parts=st.session_state.get("parts"),
         subsets=st.session_state.get("subsets"),
         auto_subsets=False,
+        auto_parts=False,
     )
     starter_text = buf0.getvalue()
 
@@ -984,10 +985,16 @@ if file_path:
         all_node_sets.update(part_node_sets)
 
         with st.expander("Definición de materiales"):
-            use_cdb_mats = st.checkbox("Incluir materiales del CDB", value=False)
+            use_cdb_mats = st.checkbox(
+                "Incluir materiales del CDB",
+                value=False,
+                key="use_cdb_mats",
+            )
             # Desactivado por defecto para evitar añadir tarjetas vacías
             use_impact = st.checkbox(
-                "Incluir materiales de impacto", value=False
+                "Incluir materiales de impacto",
+                value=False,
+                key="use_impact",
             )
 
             if use_impact:
@@ -1859,6 +1866,7 @@ if file_path:
                         parts=st.session_state.get("parts"),
                         subsets=st.session_state.get("subsets"),
                         auto_subsets=False,
+                        auto_parts=False,
                     )
                 try:
                     validate_rad_format(str(rad_path))


### PR DESCRIPTION
## Summary
- keep materials checkboxes under stable session keys
- check session state using the new keys
- disable auto-generated PART cards when previewing materials

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861b2202dd483278b964037a85efed6