### PR TITLE
Fix default property generation

### DIFF
--- a/cdb2rad/rad_preview.py
+++ b/cdb2rad/rad_preview.py
@@ -73,6 +73,8 @@ def preview_material(mat: Dict[str, Any]) -> str:
         materials={int(mat.get("id", 1)): mat},
         include_inc=False,
         default_material=False,
+        auto_properties=False,
+        auto_parts=False,
     )
     return _extract_block(buf.getvalue(), "/MAT/")
 

--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -229,6 +229,8 @@ def write_starter(
     subsets: Dict[str, List[int]] | None = None,
     auto_subsets: bool = True,
     default_material: bool = True,
+    auto_properties: bool = True,
+    auto_parts: bool = True,
     unit_sys: str | None = None,
 ) -> None:
     """Write a Radioss starter file (``*_0000.rad``).
@@ -236,7 +238,9 @@ def write_starter(
     ``unit_sys`` can be set to ``"SI"`` to output the ``/BEGIN`` card with
     kilogram--millimeter--millisecond units as used in legacy examples.
     Set ``auto_subsets=False`` to avoid generating ``/SUBSET`` cards
-    from element groups referenced in ``parts``.
+    from element groups referenced in ``parts``. ``auto_properties`` and
+    ``auto_parts`` control whether placeholder ``/PROP`` and ``/PART`` cards
+    are inserted when no definitions are provided but materials exist.
     """
 
     all_mats, mid_map = _merge_materials(materials, extra_materials)
@@ -246,11 +250,11 @@ def write_starter(
     if all_mats:
         all_mats = apply_default_materials(all_mats)
 
-    if (not properties or not parts) and all_mats:
-        from .utils import element_summary
-        _, kw_counts = element_summary(elements)
-        is_shell = kw_counts.get("SHELL", 0) >= kw_counts.get("BRICK", 0)
-        if not properties:
+    if all_mats:
+        if auto_properties and not properties:
+            from .utils import element_summary
+            _, kw_counts = element_summary(elements)
+            is_shell = kw_counts.get("SHELL", 0) >= kw_counts.get("BRICK", 0)
             if is_shell:
                 properties = [
                     {
@@ -269,7 +273,8 @@ def write_starter(
                         "Isolid": 24,
                     }
                 ]
-        if not parts:
+
+        if auto_parts and not parts and properties:
             mat_id = next(iter(all_mats.keys()), 1)
             parts = [
                 {
@@ -872,6 +877,8 @@ def write_rad(
     auto_subsets: bool = True,
     include_run: bool = True,
     default_material: bool = True,
+    auto_properties: bool = True,
+    auto_parts: bool = True,
     unit_sys: str | None = None,
 ) -> None:
     """Generate ``model_0000.rad`` with optional solver controls.
@@ -888,7 +895,8 @@ def write_rad(
     provided. ``unit_sys`` behaves like the same argument in
     :func:`write_starter` and customizes the ``/BEGIN`` block. Use
     ``auto_subsets=False`` to skip the automatic creation of ``/SUBSET`` cards
-    from element groups when ``parts`` reference them.
+    from element groups when ``parts`` reference them. ``auto_properties`` and
+    ``auto_parts`` have the same meaning as in :func:`write_starter`.
     """
 
     all_mats, mid_map = _merge_materials(materials, extra_materials)
@@ -898,11 +906,11 @@ def write_rad(
     if all_mats:
         all_mats = apply_default_materials(all_mats)
 
-    if (not properties or not parts) and all_mats:
-        from .utils import element_summary
-        _, kw_counts = element_summary(elements)
-        is_shell = kw_counts.get("SHELL", 0) >= kw_counts.get("BRICK", 0)
-        if not properties:
+    if all_mats:
+        if auto_properties and not properties:
+            from .utils import element_summary
+            _, kw_counts = element_summary(elements)
+            is_shell = kw_counts.get("SHELL", 0) >= kw_counts.get("BRICK", 0)
             if is_shell:
                 properties = [
                     {
@@ -921,7 +929,8 @@ def write_rad(
                         "Isolid": 24,
                     }
                 ]
-        if not parts:
+
+        if auto_parts and not parts and properties:
             mat_id = next(iter(all_mats.keys()), 1)
             parts = [
                 {

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -529,8 +529,8 @@ def build_rad_text(
             part_node_sets[part["name"]] = sorted(nodes_in_part)
     all_node_sets.update(part_node_sets)
 
-    use_cdb_mats = st.session_state.get("Incluir materiales del CDB", False)
-    use_impact = st.session_state.get("Incluir materiales de impacto", False)
+    use_cdb_mats = st.session_state.get("use_cdb_mats", False)
+    use_impact = st.session_state.get("use_impact", False)
     include_inc = st.session_state.get("include_inc_rad", True)
 
     extra = None
@@ -596,31 +596,33 @@ def build_rad_text(
     if not use_default_mat and st.session_state.get("parts"):
         # Insert a generic LAW1 block when parts exist but no materials
         use_default_mat = True
-    write_starter(
-        all_nodes,
-        elements,
-        buf0,
-        mesh_inc="mesh.inc",
-        include_inc=include_inc,
-        node_sets=all_node_sets,
-        elem_sets=all_elem_sets,
-        materials=materials if use_cdb_mats else None,
-        extra_materials=extra,
-        default_material=use_default_mat,
-        runname=runname,
-        unit_sys=st.session_state.get("unit_sys", UNIT_OPTIONS[0]),
-        boundary_conditions=st.session_state.get("bcs"),
-        interfaces=st.session_state.get("interfaces"),
-        rbody=st.session_state.get("rbodies"),
-        rbe2=st.session_state.get("rbe2"),
-        rbe3=st.session_state.get("rbe3"),
-        init_velocity=st.session_state.get("init_vel"),
-        gravity=st.session_state.get("gravity"),
-        properties=st.session_state.get("properties"),
-        parts=st.session_state.get("parts"),
-        subsets=st.session_state.get("subsets"),
-        auto_subsets=False,
-    )
+        write_starter(
+            all_nodes,
+            elements,
+            buf0,
+            mesh_inc="mesh.inc",
+            include_inc=include_inc,
+            node_sets=all_node_sets,
+            elem_sets=all_elem_sets,
+            materials=materials if use_cdb_mats else None,
+            extra_materials=extra,
+            default_material=use_default_mat,
+            runname=runname,
+            unit_sys=st.session_state.get("unit_sys", UNIT_OPTIONS[0]),
+            boundary_conditions=st.session_state.get("bcs"),
+            interfaces=st.session_state.get("interfaces"),
+            rbody=st.session_state.get("rbodies"),
+            rbe2=st.session_state.get("rbe2"),
+            rbe3=st.session_state.get("rbe3"),
+            init_velocity=st.session_state.get("init_vel"),
+            gravity=st.session_state.get("gravity"),
+            properties=st.session_state.get("properties"),
+            parts=st.session_state.get("parts"),
+            subsets=st.session_state.get("subsets"),
+            auto_subsets=False,
+            auto_properties=False,
+            auto_parts=False,
+        )
     starter_text = buf0.getvalue()
 
     buf1 = StringIO()
@@ -984,10 +986,16 @@ if file_path:
         all_node_sets.update(part_node_sets)
 
         with st.expander("Definición de materiales"):
-            use_cdb_mats = st.checkbox("Incluir materiales del CDB", value=False)
+            use_cdb_mats = st.checkbox(
+                "Incluir materiales del CDB",
+                value=False,
+                key="use_cdb_mats",
+            )
             # Desactivado por defecto para evitar añadir tarjetas vacías
             use_impact = st.checkbox(
-                "Incluir materiales de impacto", value=False
+                "Incluir materiales de impacto",
+                value=False,
+                key="use_impact",
             )
 
             if use_impact:
@@ -1859,6 +1867,8 @@ if file_path:
                         parts=st.session_state.get("parts"),
                         subsets=st.session_state.get("subsets"),
                         auto_subsets=False,
+                        auto_properties=False,
+                        auto_parts=False,
                     )
                 try:
                     validate_rad_format(str(rad_path))


### PR DESCRIPTION
## Summary
- disable auto property cards when building the RAD text and files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861b2202dd483278b964037a85efed6