### PR TITLE
Add alias --rad and --all flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,9 @@ cdb2rad/
 ├── mapping.json      # Maps Ansys ETYPES to Radioss keywords
 
 scripts/
-└── run_all.py        # CLI wrapper (--rad, --inc, --all)
+└── run_all.py        # CLI wrapper (--starter, --engine, --inc)
+                       # --rad is a deprecated alias for --starter
+                       # --all generates default output files
 ```
 
 ## 📌 Expected agent behavior

--- a/README.md
+++ b/README.md
@@ -108,21 +108,24 @@ del ``starter`` y los ficheros ``engine``.
 ## Ejemplo de uso
 
 ```bash
-python scripts/run_all.py data_files/model.cdb --inc mesh.inc --rad model_0000.rad
+python scripts/run_all.py data_files/model.cdb --inc mesh.inc --starter model_0000.rad
 ```
+
+El parámetro `--rad` sigue funcionando como alias de `--starter`, pero está
+deprecado y se mantiene solo para compatibilidad.
 
 Por defecto, ``model_0000.rad`` incluye la línea ``#include mesh.inc``. Con la
 opción ``--skip-include`` se genera el ``.rad`` sin esa referencia:
 
 ```bash
-python scripts/run_all.py data_files/model.cdb --rad model.rad --skip-include
+python scripts/run_all.py data_files/model.cdb --starter model.rad --skip-include
 ```
 
 Si se desea ignorar completamente los materiales leídos del ``.cdb`` basta con
 añadir ``--no-cdb-materials``:
 
 ```bash
-python scripts/run_all.py data_files/model.cdb --rad sin_mats.rad --no-cdb-materials --no-default-material
+python scripts/run_all.py data_files/model.cdb --starter sin_mats.rad --no-cdb-materials --no-default-material
 ```
 
 Si se omite ``--no-default-material`` y existen tarjetas ``/PART``, el script
@@ -133,7 +136,15 @@ Para generar un ``.rad`` limpio sin tarjetas de control ni material por defecto
 pueden emplearse las opciones ``--no-run-cards`` y ``--no-default-material``:
 
 ```bash
-python scripts/run_all.py data_files/model.cdb --rad vacio.rad --no-run-cards --no-default-material
+python scripts/run_all.py data_files/model.cdb --starter vacio.rad --no-run-cards --no-default-material
+```
+
+La opción `--all` permite generar automáticamente los tres ficheros básicos
+(``mesh.inc``, ``model_0000.rad`` y ``model_0001.rad``) si no se indican rutas
+de salida:
+
+```bash
+python scripts/run_all.py data_files/model.cdb --all
 ```
 
 ### Entorno virtual y OpenRadioss
@@ -149,7 +160,7 @@ python scripts/download_openradioss.py
 Después se puede ejecutar OpenRadioss sobre el fichero generado:
 
 ```bash
-python scripts/run_all.py data_files/model.cdb --rad model.rad \
+python scripts/run_all.py data_files/model.cdb --starter model.rad \
     --exec openradioss_bin/OpenRadioss/exec/starter_linux64_gf
 ```
 

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -18,8 +18,18 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Process .cdb file")
     parser.add_argument("cdb_file", help="Input .cdb file")
     parser.add_argument("--starter", dest="starter", help="Output starter file")
+    parser.add_argument(
+        "--rad",
+        dest="starter",
+        help="Deprecated alias for --starter",
+    )
     parser.add_argument("--engine", dest="engine", help="Output engine file")
     parser.add_argument("--inc", dest="inc", help="Output mesh.inc file")
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Generate starter, engine and inc with default names",
+    )
     parser.add_argument("--exec", dest="exec_path", help="Run OpenRadioss starter after generation")
     parser.add_argument(
         "--skip-include",
@@ -44,10 +54,10 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    if not args.starter and not args.engine and not args.inc:
-        args.inc = "mesh.inc"
-        args.starter = "model_0000.rad"
-        args.engine = "model_0001.rad"
+    if args.all or not (args.starter or args.engine or args.inc):
+        args.inc = args.inc or "mesh.inc"
+        args.starter = args.starter or "model_0000.rad"
+        args.engine = args.engine or "model_0001.rad"
 
     nodes, elements, node_sets, elem_sets, materials = parse_cdb(args.cdb_file)
 

--- a/tests/test_run_all_cli.py
+++ b/tests/test_run_all_cli.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import subprocess
+
+DATA = Path(__file__).resolve().parents[1] / 'data' / 'model.cdb'
+SCRIPT = Path(__file__).resolve().parents[1] / 'scripts' / 'run_all.py'
+
+
+def test_rad_alias(tmp_path):
+    starter = tmp_path / 'alias.rad'
+    result = subprocess.run([
+        'python', str(SCRIPT), str(DATA), '--rad', str(starter)
+    ], capture_output=True, text=True, cwd=tmp_path)
+    assert starter.exists()
+
+
+def test_all_flag(tmp_path):
+    result = subprocess.run([
+        'python', str(SCRIPT), str(DATA), '--all'
+    ], capture_output=True, text=True, cwd=tmp_path)
+    assert (tmp_path / 'mesh.inc').exists()
+    assert (tmp_path / 'model_0000.rad').exists()
+    assert (tmp_path / 'model_0001.rad').exists()
+


### PR DESCRIPTION
## Summary
- extend `run_all.py` CLI with `--rad` alias and new `--all` flag
- document flags in README and AGENTS guidelines
- test CLI usage with the new arguments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862562f95548327b183f80aa7ed2838