### PR TITLE
Disable automatic part generation

### DIFF
--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -230,7 +230,7 @@ def write_starter(
     auto_subsets: bool = True,
     default_material: bool = True,
     auto_properties: bool = True,
-    auto_parts: bool = True,
+    auto_parts: bool = False,
     unit_sys: str | None = None,
 ) -> None:
     """Write a Radioss starter file (``*_0000.rad``).
@@ -238,9 +238,10 @@ def write_starter(
     ``unit_sys`` can be set to ``"SI"`` to output the ``/BEGIN`` card with
     kilogram--millimeter--millisecond units as used in legacy examples.
     Set ``auto_subsets=False`` to avoid generating ``/SUBSET`` cards
-    from element groups referenced in ``parts``. ``auto_properties`` and
-    ``auto_parts`` control whether placeholder ``/PROP`` and ``/PART`` cards
-    are inserted when no definitions are provided but materials exist.
+    from element groups referenced in ``parts``. ``auto_properties`` controls
+    whether placeholder ``/PROP`` cards are inserted when no properties are
+    provided but materials exist. ``auto_parts`` (``False`` by default) creates
+    a default ``/PART`` only when set to ``True`` and no parts are supplied.
     """
 
     all_mats, mid_map = _merge_materials(materials, extra_materials)
@@ -878,7 +879,7 @@ def write_rad(
     include_run: bool = True,
     default_material: bool = True,
     auto_properties: bool = True,
-    auto_parts: bool = True,
+    auto_parts: bool = False,
     unit_sys: str | None = None,
 ) -> None:
     """Generate ``model_0000.rad`` with optional solver controls.
@@ -895,8 +896,10 @@ def write_rad(
     provided. ``unit_sys`` behaves like the same argument in
     :func:`write_starter` and customizes the ``/BEGIN`` block. Use
     ``auto_subsets=False`` to skip the automatic creation of ``/SUBSET`` cards
-    from element groups when ``parts`` reference them. ``auto_properties`` and
-    ``auto_parts`` have the same meaning as in :func:`write_starter`.
+    from element groups when ``parts`` reference them. ``auto_properties`` has
+    the same meaning as in :func:`write_starter`. ``auto_parts`` (``False`` by
+    default) inserts a placeholder ``/PART`` only when set to ``True`` and no
+    parts are defined.
     """
 
     all_mats, mid_map = _merge_materials(materials, extra_materials)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -308,7 +308,7 @@ def test_write_rad_no_materials(tmp_path):
 def test_write_rad_auto_parts(tmp_path):
     nodes, elements, _, _, mats = parse_cdb(DATA)
     rad = tmp_path / 'auto_0000.rad'
-    write_starter(nodes, elements, str(rad), materials=mats)
+    write_starter(nodes, elements, str(rad), materials=mats, auto_parts=True)
     txt = rad.read_text()
     assert '/PROP/' in txt
     assert '/PART/1' in txt


### PR DESCRIPTION
## Summary
- `write_starter` and `write_rad` no longer create `/PART` cards by default
- clarify docstrings for the new behaviour
- update unit test to request `auto_parts=True`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686256c5d0188327b33f299c84379361