### PR TITLE
Handle RAD generation failure cleanup

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1879,6 +1879,10 @@ if file_path:
                     st.error(
                         "Material ID no definido. Activa 'Incluir materiales del CDB' o define el material en la sección de impacto."
                     )
+                    Path(rad_path).unlink(missing_ok=True)
+                    if not include_inc:
+                        Path(mesh_path).unlink(missing_ok=True)
+                    st.stop()
                 else:
                     try:
                         validate_rad_format(str(rad_path))


### PR DESCRIPTION
## Summary
- handle errors when creating RAD files via dashboard
- delete partial outputs with `Path.unlink`
- stop execution so invalid files aren't shown

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686262032318832798593dfcbbe1da2c