### PR TITLE
Add 'Exportar copia' option in RAD editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,10 @@ pestañas principales:
 
 - **Generar RAD** para introducir parámetros de cálculo, definir **Propiedades** y obtener
   ``model_0000.rad``.
+
+- **Editor RAD** permite revisar los ficheros generados y editarlos manualmente.
+  Con el campo *Guardar como* y el botón **Exportar copia** se puede crear una
+  copia con otro nombre en el mismo directorio de salida.
 Dentro de esta pestaña se incluye un bloque **Propiedades** donde se pueden crear tarjetas `/PROP` y asignarlas a `/PART` mediante el ID de material. Las tablas de propiedades y partes se muestran antes de generar el archivo. Además, existen botones rápidos para generar propiedades **Hexa8**, **Tetra4** y **Quad4** con parámetros recomendados por la ayuda de Radioss.
 Se incluyen casillas opcionales para **sobrescribir** los archivos
 ``.inc`` o ``.rad`` si ya existen en el directorio de salida.

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1988,6 +1988,12 @@ if file_path:
             height=300,
         )
 
+        export_name = st.text_input(
+            "Guardar como",
+            value="",
+            key="rad_export_name",
+        )
+
         if st.button("Guardar .rad", key="save_rad_editor"):
             out_dir = Path(
                 st.session_state.get("rad_dir", st.session_state.get("work_dir", str(Path.cwd())))
@@ -1999,6 +2005,19 @@ if file_path:
             starter_path.write_text(st.session_state["rad_editor_starter"])
             engine_path.write_text(st.session_state["rad_editor_engine"])
             st.success(f"Archivos guardados en: {starter_path} y {engine_path}")
+
+        if st.button("Exportar copia", key="export_rad_editor") and export_name:
+            out_dir = Path(
+                st.session_state.get("rad_dir", st.session_state.get("work_dir", str(Path.cwd())))
+            ).expanduser()
+            out_dir.mkdir(parents=True, exist_ok=True)
+            starter_copy = out_dir / f"{export_name}_0000.rad"
+            engine_copy = out_dir / f"{export_name}_0001.rad"
+            starter_copy.write_text(st.session_state["rad_editor_starter"])
+            engine_copy.write_text(st.session_state["rad_editor_engine"])
+            st.success(
+                f"Archivos exportados en: {starter_copy} y {engine_copy}"
+            )
 
     with help_tab:
         st.subheader("Documentación")


### PR DESCRIPTION
## Summary
- add text input to specify export file name
- support exporting edited RAD files via new "Exportar copia" button
- document save-as feature in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686268b9e4d883279a981df6a9038a49