### PR TITLE
Fix preview_part for custom material IDs

### DIFF
--- a/cdb2rad/rad_preview.py
+++ b/cdb2rad/rad_preview.py
@@ -94,13 +94,15 @@ def preview_property(prop: Dict[str, Any]) -> str:
 
 def preview_part(part: Dict[str, Any]) -> str:
     buf = StringIO()
+    mid = int(part.get("mid", 1))
     write_starter(
         _BASIC_NODES,
         _BASIC_ELEMS,
         buf,
         parts=[part],
+        materials={mid: {}},
         include_inc=False,
-        default_material=True,
+        default_material=False,
     )
     return _extract_block(buf.getvalue(), f"/PART/{part.get('id',1)}")
 

--- a/tests/test_rad_preview.py
+++ b/tests/test_rad_preview.py
@@ -15,6 +15,12 @@ def test_preview_part_no_material():
     assert "P1" in txt
 
 
+def test_preview_part_custom_mid():
+    part = {"id": 1, "name": "P1", "pid": 1, "mid": 2}
+    txt = rad_preview.preview_part(part)
+    assert "/PART/1" in txt
+
+
 
 def test_preview_bc_types():
     bc_fix = {"type": "BCS", "name": "Fix", "tra": "111", "rot": "111"}


### PR DESCRIPTION
## Summary
- ensure part previews create a temporary material matching the part's MID
- test preview_part with non-default material ID

## Testing
- `pytest tests/test_rad_preview.py::test_preview_part_custom_mid -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68626cbc6fb0832780b2b2f25aaf0274