### PR TITLE
Fix subset mapping for numeric keys

### DIFF
--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -604,7 +604,7 @@ def write_starter(
                 all_subsets.update(auto_subsets_dict)
 
             subset_map: Dict[str, int] = {
-                n: i for i, n in enumerate(all_subsets.keys(), start=1)
+                str(n): i for i, n in enumerate(all_subsets.keys(), start=1)
             }
 
             for p in mapped_parts:
@@ -1330,7 +1330,7 @@ def write_rad(
                 all_subsets.update(auto_subsets_dict)
 
             subset_map: Dict[str, int] = {
-                n: i for i, n in enumerate(all_subsets.keys(), start=1)
+                str(n): i for i, n in enumerate(all_subsets.keys(), start=1)
             }
 
             for p in mapped_parts:

--- a/tests/test_part_mapping.py
+++ b/tests/test_part_mapping.py
@@ -46,3 +46,27 @@ def test_invalid_part_material(tmp_path):
             properties=props,
             parts=parts,
         )
+
+
+def test_part_subset_numeric(tmp_path):
+    nodes, elements, node_sets, elem_sets, mats = parse_cdb(DATA)
+    props = [{'id': 1, 'name': 'shell_p', 'type': 'SHELL', 'thickness': 1.0}]
+    parts = [{'id': 1, 'name': 'p1', 'pid': 1, 'mid': 1, 'set': 1}]
+    subsets = {1: [elements[0][0]]}
+    rad = tmp_path / 'subset_0000.rad'
+    write_starter(
+        nodes,
+        elements,
+        str(rad),
+        node_sets=node_sets,
+        elem_sets=elem_sets,
+        materials=mats,
+        properties=props,
+        parts=parts,
+        subsets=subsets,
+        auto_subsets=False,
+    )
+    lines = rad.read_text().splitlines()
+    idx = lines.index('/PART/1')
+    subset_id = int(lines[idx + 2].split()[-1])
+    assert subset_id == 1


### PR DESCRIPTION
## Summary
- fix subset_map comprehension to convert keys to string
- ensure part subset IDs are mapped when keys are numeric
- add regression test for numeric subset mapping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686294390fb48327a127d19d11ed8595