### PR TITLE
Add subset test for write_rad

### DIFF
--- a/tests/test_part_mapping.py
+++ b/tests/test_part_mapping.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 from cdb2rad.parser import parse_cdb
-from cdb2rad.writer_rad import write_starter
+from cdb2rad.writer_rad import write_starter, write_rad
 
 DATA = os.path.join(os.path.dirname(__file__), '..', 'data', 'model.cdb')
 
@@ -55,6 +55,30 @@ def test_part_subset_numeric(tmp_path):
     subsets = {1: [elements[0][0]]}
     rad = tmp_path / 'subset_0000.rad'
     write_starter(
+        nodes,
+        elements,
+        str(rad),
+        node_sets=node_sets,
+        elem_sets=elem_sets,
+        materials=mats,
+        properties=props,
+        parts=parts,
+        subsets=subsets,
+        auto_subsets=False,
+    )
+    lines = rad.read_text().splitlines()
+    idx = lines.index('/PART/1')
+    subset_id = int(lines[idx + 2].split()[-1])
+    assert subset_id == 1
+
+
+def test_write_rad_part_subset(tmp_path):
+    nodes, elements, node_sets, elem_sets, mats = parse_cdb(DATA)
+    props = [{'id': 1, 'name': 'shell_p', 'type': 'SHELL', 'thickness': 1.0}]
+    parts = [{'id': 1, 'name': 'p1', 'pid': 1, 'mid': 1, 'set': 1}]
+    subsets = {1: [elements[0][0]]}
+    rad = tmp_path / 'subset_full.rad'
+    write_rad(
         nodes,
         elements,
         str(rad),


### PR DESCRIPTION
## Summary
- verify part subset mapping when using `write_rad`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862972d3e9c83278387b819609a0901