### PR TITLE
Add subset mapping test

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -620,7 +620,7 @@ def build_rad_text(
             properties=st.session_state.get("properties"),
             parts=st.session_state.get("parts"),
             subsets=st.session_state.get("subsets"),
-            auto_subsets=False,
+            auto_subsets=True,
             auto_parts=False,
         )
     except ValueError as e:
@@ -1872,7 +1872,7 @@ if file_path:
                         properties=st.session_state.get("properties"),
                         parts=st.session_state.get("parts"),
                         subsets=st.session_state.get("subsets"),
-                        auto_subsets=False,
+                        auto_subsets=True,
                         auto_parts=False,
                     )
                 except ValueError as e:

--- a/tests/test_part_mapping.py
+++ b/tests/test_part_mapping.py
@@ -94,3 +94,68 @@ def test_write_rad_part_subset(tmp_path):
     idx = lines.index('/PART/1')
     subset_id = int(lines[idx + 2].split()[-1])
     assert subset_id == 1
+
+def test_two_parts_two_subsets(tmp_path):
+    nodes, elements, node_sets, elem_sets, mats = parse_cdb(DATA)
+    props = [{'id': 1, 'name': 'shell_p', 'type': 'SHELL', 'thickness': 1.0}]
+    parts = [
+        {'id': 1, 'name': 'p1', 'pid': 1, 'mid': 1, 'set': 1},
+        {'id': 2, 'name': 'p2', 'pid': 1, 'mid': 1, 'set': 2},
+    ]
+    subsets = {
+        1: [elements[0][0]],
+        2: [elements[1][0]],
+    }
+    rad = tmp_path / 'multi_subset.rad'
+    write_starter(
+        nodes,
+        elements,
+        str(rad),
+        node_sets=node_sets,
+        elem_sets=elem_sets,
+        materials=mats,
+        properties=props,
+        parts=parts,
+        subsets=subsets,
+        auto_subsets=False,
+    )
+    lines = rad.read_text().splitlines()
+    idx1 = lines.index('/PART/1')
+    idx2 = lines.index('/PART/2')
+    subset_id1 = int(lines[idx1 + 2].split()[-1])
+    subset_id2 = int(lines[idx2 + 2].split()[-1])
+    assert subset_id1 == 1
+    assert subset_id2 == 2
+
+
+def test_two_parts_two_subsets_write_rad(tmp_path):
+    nodes, elements, node_sets, elem_sets, mats = parse_cdb(DATA)
+    props = [{'id': 1, 'name': 'shell_p', 'type': 'SHELL', 'thickness': 1.0}]
+    parts = [
+        {'id': 1, 'name': 'p1', 'pid': 1, 'mid': 1, 'set': 1},
+        {'id': 2, 'name': 'p2', 'pid': 1, 'mid': 1, 'set': 2},
+    ]
+    subsets = {
+        1: [elements[0][0]],
+        2: [elements[1][0]],
+    }
+    rad = tmp_path / 'multi_subset_full.rad'
+    write_rad(
+        nodes,
+        elements,
+        str(rad),
+        node_sets=node_sets,
+        elem_sets=elem_sets,
+        materials=mats,
+        properties=props,
+        parts=parts,
+        subsets=subsets,
+        auto_subsets=False,
+    )
+    lines = rad.read_text().splitlines()
+    idx1 = lines.index('/PART/1')
+    idx2 = lines.index('/PART/2')
+    subset_id1 = int(lines[idx1 + 2].split()[-1])
+    subset_id2 = int(lines[idx2 + 2].split()[-1])
+    assert subset_id1 == 1
+    assert subset_id2 == 2


### PR DESCRIPTION
## Summary
- add regression test for multiple subsets with multiple parts
- verify mapping in write_rad
- use auto_subsets in dashboard to ensure group ID selection persists

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862a5d67db483279cfd240bd193f9c0