### PR TITLE
Fix duplicate return logic in writer_rad

### DIFF
--- a/cdb2rad/writer_rad.py
+++ b/cdb2rad/writer_rad.py
@@ -778,16 +778,6 @@ def write_starter(
         return None, subset_map
     return None
 
-    if return_subset_map:
-        return None, subset_map
-    return None
-    if return_subset_map:
-        return None, subset_map
-    return None
-    if return_subset_map:
-        return None, subset_map
-    return None
-
 def write_engine(
     outfile: str | TextIO,
     *,


### PR DESCRIPTION
## Summary
- remove duplicated return statements at the end of `write_starter`
- ensure function finishes with a single conditional return

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862ffc68144832794f021deee561cc9