### PR TITLE
Fix duplicate lines in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,11 +227,7 @@ pestañas principales:
   `C:\JAVIER\OPEN_RADIOSS\paraview\data` como directorio de salida.
 - **Propiedades** permite definir propiedades y partes que luego se incluirán en
   el ``starter``.
-- **Generar INC** permite crear ``mesh.inc`` y muestra sus primeras líneas. \
-
-
-- **Generar INC** permite crear ``mesh.inc`` y muestra sus primeras líneas. \
-
+- **Generar INC** permite crear ``mesh.inc`` y muestra sus primeras líneas.
   Incluye casillas para decidir si exportar las selecciones nombradas y los
   materiales. La tabla **Grupos importados** indica el tipo de elemento en
   Radioss y el nombre Ansys asociado a cada conjunto.


### PR DESCRIPTION
## Summary
- remove duplicate `Generar INC` sentence in the dashboard section of README
- clean up stray backslashes so the paragraph reads correctly

## Testing
- `pytest -q` *(fails: test_write_rad)*

------
https://chatgpt.com/codex/tasks/task_e_6863c93389088327bf73c826aff9f81c