### PR TITLE
Enable automatic subset creation in dashboard

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -621,7 +621,6 @@ def build_rad_text(
             properties=st.session_state.get("properties"),
             parts=st.session_state.get("parts"),
             subsets=st.session_state.get("subsets"),
-            auto_subsets=False,
             auto_parts=False,
         )
     except ValueError as e:
@@ -1879,7 +1878,6 @@ if file_path:
                         properties=st.session_state.get("properties"),
                         parts=st.session_state.get("parts"),
                         subsets=st.session_state.get("subsets"),
-                        auto_subsets=False,
                         auto_parts=False,
                     )
                 except ValueError as e:


### PR DESCRIPTION
## Summary
- use default automatic subset creation when building starter decks from the dashboard
- keep dropdowns and other logic unchanged

## Testing
- `pytest -q`
- `pytest tests/test_part_mapping.py::test_existing_group_id_reused -q`


------
https://chatgpt.com/codex/tasks/task_e_6863cee7decc83279aeebcce2ee49143