### PR TITLE
Handle FRICTION validation

### DIFF
--- a/cdb2rad/rad_validator.py
+++ b/cdb2rad/rad_validator.py
@@ -115,6 +115,63 @@ def _validate_subset(lines: list[str], idx: int) -> int:
     return i - 1
 
 
+def _validate_friction(lines: list[str], idx: int) -> int:
+    """Validate a ``/FRICTION`` block starting at ``idx``.
+
+    The function supports the single-line variant (coefficient only or
+    coefficient plus stiffness) and the multi-line form with ``Ifric``,
+    ``Ifiltr``, ``Xfreq``, ``Iform`` followed by ``C1``--``C5`` and
+    ``C6``, ``Fric``, ``VISF`` as described in the 2022 Reference Guide.
+    It returns the index of the last line belonging to the block.
+    """
+
+    if idx + 1 >= len(lines):
+        raise ValueError("Incomplete /FRICTION block")
+
+    j = idx + 1
+    first = lines[j].strip()
+    if not first:
+        raise ValueError("Missing /FRICTION data")
+
+    tokens = first.split()
+    if all(_is_number(t) for t in tokens):
+        if len(tokens) not in (1, 2):
+            raise ValueError("Invalid /FRICTION values")
+        return j
+
+    # multi-line form: first line is a title
+    j += 1
+    def _skip_comments(k: int) -> int:
+        while k < len(lines) and (not lines[k].strip() or lines[k].lstrip().startswith("#")):
+            k += 1
+        return k
+
+    j = _skip_comments(j)
+    if j >= len(lines):
+        raise ValueError("Incomplete /FRICTION block")
+    parts = lines[j].split()
+    if len(parts) != 4 or not all(_is_number(t) for t in parts):
+        raise ValueError("Invalid /FRICTION header values")
+
+    j += 1
+    j = _skip_comments(j)
+    if j >= len(lines):
+        raise ValueError("Incomplete /FRICTION block")
+    parts = lines[j].split()
+    if len(parts) != 5 or not all(_is_number(t) for t in parts):
+        raise ValueError("Invalid /FRICTION coefficients")
+
+    j += 1
+    j = _skip_comments(j)
+    if j >= len(lines):
+        raise ValueError("Incomplete /FRICTION block")
+    parts = lines[j].split()
+    if len(parts) != 3 or not all(_is_number(t) for t in parts):
+        raise ValueError("Invalid /FRICTION footer values")
+
+    return j
+
+
 def validate_rad_format(filepath: str) -> None:
     """Validate the structure of ``filepath``.
 
@@ -171,17 +228,19 @@ def validate_rad_format(filepath: str) -> None:
                 j += 1
             if j >= len(lines):
                 raise ValueError("TYPE7 missing /FRICTION")
+            j = _validate_friction(lines, j)
             if j + 1 >= len(lines):
                 raise ValueError("Incomplete TYPE7 block")
-            i = j + 2
+            i = j + 1
             continue
 
         if line.startswith("/INTER/TYPE2"):
-            if i + 4 >= len(lines):
+            if i + 3 >= len(lines):
                 raise ValueError("Incomplete TYPE2 block")
             if not lines[i + 3].startswith("/FRICTION"):
                 raise ValueError("TYPE2 missing /FRICTION")
-            i += 5
+            j = _validate_friction(lines, i + 3)
+            i = j + 1
             continue
 
         if line.startswith("/RBODY/"):
@@ -221,6 +280,11 @@ def validate_rad_format(filepath: str) -> None:
             if not all(_is_number(t) for t in lines[i + 2].split()):
                 raise ValueError("Invalid gravity vector")
             i += 3
+            continue
+
+        if line.startswith("/FRICTION"):
+            i = _validate_friction(lines, i)
+            i += 1
             continue
 
         if line.startswith("/"):

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -52,3 +52,19 @@ def test_validate_subset(tmp_path):
     rad = tmp_path / "subset.rad"
     rad.write_text("/SUBSET/1\nset1\n1 2 3\n/END\n")
     validate_rad_format(str(rad))
+
+
+def test_invalid_friction_simple(tmp_path):
+    rad = tmp_path / "bad_fric.rad"
+    rad.write_text("/FRICTION\n1 2 3\n")
+    with pytest.raises(ValueError):
+        validate_rad_format(str(rad))
+
+
+def test_invalid_friction_multi(tmp_path):
+    rad = tmp_path / "bad_fric_multi.rad"
+    rad.write_text(
+        "/FRICTION\ntitle\n0 0 0 2\n0 0 0 0 0\n0 0\n"
+    )
+    with pytest.raises(ValueError):
+        validate_rad_format(str(rad))


### PR DESCRIPTION
## Summary
- add parser for `/FRICTION` blocks in validator
- hook validator into TYPE2/TYPE7 parsing and stand‑alone friction blocks
- test malformed friction blocks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863e26506608327b66fcaad43436263