### PR TITLE
Support groups in VTK export

### DIFF
--- a/cdb2rad/mesh_convert.py
+++ b/cdb2rad/mesh_convert.py
@@ -27,8 +27,14 @@ def convert_to_vtk(infile: str, outfile: str) -> None:
     """
     ext = Path(infile).suffix.lower()
     if ext == ".cdb":
-        nodes, elements, *_ = parse_cdb(infile)
-        write_vtk(nodes, elements, outfile)
+        nodes, elements, node_sets, elem_sets, _ = parse_cdb(infile)
+        write_vtk(
+            nodes,
+            elements,
+            outfile,
+            node_sets=node_sets,
+            elem_sets=elem_sets,
+        )
         return
 
     if meshio is None:
@@ -44,12 +50,14 @@ def mesh_to_temp_vtk(
     nodes: Dict[int, List[float]],
     elements: List[Tuple[int, int, List[int]]],
     suffix: str = ".vtk",
+    node_sets: Dict[str, List[int]] | None = None,
+    elem_sets: Dict[str, List[int]] | None = None,
 ) -> str:
-    """Return path to a temporary VTK/VTP file for *nodes* and *elements*."""
+    """Return path to a temporary VTK/VTP file with optional groups."""
     tmp = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
     tmp.close()
     if suffix.endswith(".vtp"):
-        write_vtp(nodes, elements, tmp.name)
+        write_vtp(nodes, elements, tmp.name, node_sets=node_sets, elem_sets=elem_sets)
     else:
-        write_vtk(nodes, elements, tmp.name)
+        write_vtk(nodes, elements, tmp.name, node_sets=node_sets, elem_sets=elem_sets)
     return tmp.name

--- a/cdb2rad/vtk_writer.py
+++ b/cdb2rad/vtk_writer.py
@@ -11,8 +11,10 @@ def write_vtk(
     nodes: Dict[int, List[float]],
     elements: List[Tuple[int, int, List[int]]],
     outfile: str,
+    node_sets: Dict[str, List[int]] | None = None,
+    elem_sets: Dict[str, List[int]] | None = None,
 ) -> None:
-    """Write an ASCII VTK UnstructuredGrid file."""
+    """Write an ASCII VTK UnstructuredGrid file including optional groups."""
     # map node ids to 0-based indices
     id_map = {nid: i for i, nid in enumerate(sorted(nodes))}
 
@@ -47,13 +49,33 @@ def write_vtk(
                 ctype = 7  # POLYGON
             f.write(f"{ctype}\n")
 
+        if node_sets:
+            f.write(f"\nPOINT_DATA {len(nodes)}\n")
+            for name, nids in node_sets.items():
+                f.write(f"SCALARS {name} int 1\n")
+                f.write("LOOKUP_TABLE default\n")
+                nid_set = set(nids)
+                for nid in sorted(nodes):
+                    f.write(f"{1 if nid in nid_set else 0}\n")
+
+        if elem_sets:
+            f.write(f"\nCELL_DATA {len(elements)}\n")
+            for name, eids in elem_sets.items():
+                f.write(f"SCALARS {name} int 1\n")
+                f.write("LOOKUP_TABLE default\n")
+                eid_set = set(eids)
+                for eid, _, _ in elements:
+                    f.write(f"{1 if eid in eid_set else 0}\n")
+
 
 def write_vtp(
     nodes: Dict[int, List[float]],
     elements: List[Tuple[int, int, List[int]]],
     outfile: str,
+    node_sets: Dict[str, List[int]] | None = None,
+    elem_sets: Dict[str, List[int]] | None = None,
 ) -> None:
-    """Write a VTK PolyData ``.vtp`` file.
+    """Write a VTK PolyData ``.vtp`` file including optional groups.
 
     Requires :mod:`vtk`. Elements are exported as polygons so both surface and
     solid meshes can be visualised. When ``vtk`` is not available a
@@ -89,6 +111,30 @@ def write_vtp(
                 f.write(f"{offset} ")
             f.write('\n</DataArray>\n')
             f.write('</Polys>\n')
+            if node_sets:
+                f.write('<PointData>\n')
+                for name, nids in node_sets.items():
+                    nid_set = set(nids)
+                    f.write(
+                        f'<DataArray type="Int32" Name="{name}" format="ascii">\n'
+                    )
+                    vals = ["1" if nid in nid_set else "0" for nid in sorted(nodes)]
+                    f.write(" ".join(vals))
+                    f.write('\n</DataArray>\n')
+                f.write('</PointData>\n')
+            if elem_sets:
+                f.write('<CellData>\n')
+                for name, eids in elem_sets.items():
+                    eid_set = set(eids)
+                    f.write(
+                        f'<DataArray type="Int32" Name="{name}" format="ascii">\n'
+                    )
+                    vals = [
+                        "1" if eid in eid_set else "0" for eid, _, _ in elements
+                    ]
+                    f.write(" ".join(vals))
+                    f.write('\n</DataArray>\n')
+                f.write('</CellData>\n')
             f.write('</Piece>\n</PolyData>\n</VTKFile>\n')
         return
 
@@ -112,6 +158,22 @@ def write_vtp(
     poly = vtk.vtkPolyData()
     poly.SetPoints(points)
     poly.SetPolys(polys)
+
+    if node_sets:
+        for name, nids in node_sets.items():
+            arr = vtk.vtkIntArray()
+            arr.SetName(name)
+            for nid in sorted(nodes):
+                arr.InsertNextValue(1 if nid in set(nids) else 0)
+            poly.GetPointData().AddArray(arr)
+
+    if elem_sets:
+        for name, eids in elem_sets.items():
+            arr = vtk.vtkIntArray()
+            arr.SetName(name)
+            for eid, _, _ in elements:
+                arr.InsertNextValue(1 if eid in set(eids) else 0)
+            poly.GetCellData().AddArray(arr)
 
     writer = vtk.vtkXMLPolyDataWriter()
     writer.SetFileName(outfile)

--- a/tests/test_convert_cli.py
+++ b/tests/test_convert_cli.py
@@ -10,3 +10,5 @@ def test_convert_cli(tmp_path):
     result = subprocess.run(['python', str(script), str(DATA), str(out)], capture_output=True, text=True)
     assert out.exists()
     assert 'Written' in result.stdout
+    text = out.read_text()
+    assert 'POINT_DATA' in text

--- a/tests/test_mesh_convert.py
+++ b/tests/test_mesh_convert.py
@@ -9,3 +9,4 @@ def test_convert_to_vtk(tmp_path):
     convert_to_vtk(str(DATA), str(out))
     text = out.read_text()
     assert 'UNSTRUCTURED_GRID' in text
+    assert 'POINT_DATA' in text

--- a/tests/test_vtk_writer.py
+++ b/tests/test_vtk_writer.py
@@ -7,19 +7,33 @@ DATA = os.path.join(os.path.dirname(__file__), '..', 'data', 'model.cdb')
 
 
 def test_write_vtk():
-    nodes, elements, *_ = parse_cdb(DATA)
+    nodes, elements, node_sets, elem_sets, _ = parse_cdb(DATA)
     with tempfile.NamedTemporaryFile(delete=False, suffix='.vtk') as tmp:
-        write_vtk(nodes, elements, tmp.name)
+        write_vtk(
+            nodes,
+            elements,
+            tmp.name,
+            node_sets=node_sets,
+            elem_sets=elem_sets,
+        )
         tmp.close()
         with open(tmp.name, 'r') as f:
             content = f.read()
     assert content.startswith('# vtk DataFile')
     assert 'DATASET UNSTRUCTURED_GRID' in content
+    assert 'POINT_DATA' in content
+    assert 'CELL_DATA' in content
 
 
 def test_write_vtp(tmp_path):
-    nodes, elements, *_ = parse_cdb(DATA)
+    nodes, elements, node_sets, elem_sets, _ = parse_cdb(DATA)
     out = tmp_path / "mesh.vtp"
-    write_vtp(nodes, elements, str(out))
+    write_vtp(
+        nodes,
+        elements,
+        str(out),
+        node_sets=node_sets,
+        elem_sets=elem_sets,
+    )
     assert out.exists() and out.stat().st_size > 0
 


### PR DESCRIPTION
## Summary
- allow `write_vtk` and `write_vtp` to include node/element groups
- propagate groups through `convert_to_vtk` and helpers
- update CLI and library tests for group output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686564985b7883279d35951b17413a8c