### PR TITLE
Add automatic part generation for mixed element types

### DIFF
--- a/cdb2rad/writer_inc.py
+++ b/cdb2rad/writer_inc.py
@@ -18,7 +18,7 @@ def write_mesh_inc(
     node_sets: Dict[str, List[int]] | None = None,
     elem_sets: Dict[str, List[int]] | None = None,
     materials: Dict[int, Dict[str, float]] | None = None,
-    dummy_part: int = 2000001,
+    dummy_part: int | Dict[str, int] = 2000001,
 ) -> None:
     """Write ``mesh.inc`` with Radioss element blocks.
 
@@ -66,7 +66,8 @@ def write_mesh_inc(
             f.write(f"{nid:10d}{x:15.6f}{y:15.6f}{z:15.6f}\n")
 
         for key, items in categorized.items():
-            f.write(f"\n/{key}/{dummy_part}\n")
+            part_id = dummy_part.get(key, 2000001) if isinstance(dummy_part, dict) else dummy_part
+            f.write(f"\n/{key}/{part_id}\n")
             for eid, nids in items:
                 line = f"{eid:10d}" + "".join(f"{nid:10d}" for nid in nids)
                 f.write(line + "\n")

--- a/model_0000.out
+++ b/model_0000.out
@@ -24,7 +24,7 @@
  COMPUTATION HARDWARE DESCRIPTION
   
  HOSTNAME     CPU TYPE, FREQUENCY AND MEMORY
- MSI   12th Gen Intel(R) Core(TM) i7-12700H (x86_64), 2687 MHz,  15843 MB RAM,   4096 MB swap
+ e561209ba397   Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz (x86_64), 2793 MHz,  10169 MB RAM,      0 MB swap
   
  STACKSIZE  . . . . . . . . . . . . . . . . . . . . 8 MB
  THREAD STACKSIZE . . . . . . . . . . . . . . . . . 0 MB

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -104,7 +104,7 @@ def main() -> None:
 
     nodes, elements, node_sets, elem_sets, materials = parse_cdb(args.cdb_file)
 
-    if args.inc:
+    if args.inc and not args.starter:
         write_mesh_inc(
             nodes,
             elements,
@@ -132,6 +132,7 @@ def main() -> None:
             elem_sets=elem_sets,
             materials=None if args.no_cdb_materials else materials,
             default_material=not args.no_default_material,
+            auto_parts=True,
         )
     if args.engine:
         write_engine(


### PR DESCRIPTION
## Summary
- auto-generate default shell and solid properties and parts when converting CDB files
- map mesh include element blocks to the correct part IDs
- only write `mesh.inc` separately when no starter file is requested

## Testing
- `pytest -q`
- `python scripts/run_all.py data/model.cdb --all --starter-exec openradioss_bin/OpenRadioss/exec/starter_linux64_gf --engine-exec openradioss_bin/OpenRadioss/exec/engine_linux64_gf --auto-env` *(fails: BADLY SHAPED 10-NODE TETRA ELEMENT)*

------
https://chatgpt.com/codex/tasks/task_e_689f83ec45e08327b279e71954c43363